### PR TITLE
fix(mcp): forward similar_case_advice to initial_write in input_writer tool

### DIFF
--- a/src/mcp/fastmcp_server.py
+++ b/src/mcp/fastmcp_server.py
@@ -186,11 +186,6 @@ async def input_writer(
 
         await ctx.info(f"Case info: {case_info}")
 
-        # Retrieve references (including the similar-case advice that the LLM
-        # uses to know which tutorial fields/schemes to copy from). This advice
-        # is the same one the LangGraph planner_node forwards to input_writer
-        # via state["similar_case_advice"]; without it, MCP-driven generation
-        # is missing context that the in-process pipeline has.
         tutorial_reference, dir_structure, dir_counts_str, allrun_reference, similar_case_advice = retrieve_references(
             case_name=case_info["case_name"],
             case_solver=case_info["case_solver"],

--- a/src/mcp/fastmcp_server.py
+++ b/src/mcp/fastmcp_server.py
@@ -186,8 +186,12 @@ async def input_writer(
 
         await ctx.info(f"Case info: {case_info}")
 
-        # Retrieve references
-        tutorial_reference, dir_structure, dir_counts_str, allrun_reference, _ = retrieve_references(
+        # Retrieve references (including the similar-case advice that the LLM
+        # uses to know which tutorial fields/schemes to copy from). This advice
+        # is the same one the LangGraph planner_node forwards to input_writer
+        # via state["similar_case_advice"]; without it, MCP-driven generation
+        # is missing context that the in-process pipeline has.
+        tutorial_reference, dir_structure, dir_counts_str, allrun_reference, similar_case_advice = retrieve_references(
             case_name=case_info["case_name"],
             case_solver=case_info["case_solver"],
             case_domain=case_info["case_domain"],
@@ -243,6 +247,7 @@ async def input_writer(
             allrun_reference=allrun_reference,
             database_path=str(global_config.database_path),
             searchdocs=global_config.searchdocs,
+            similar_case_advice=similar_case_advice,
             progress_callback=progress_callback,
         )
 

--- a/src/mcp/fastmcp_server.py
+++ b/src/mcp/fastmcp_server.py
@@ -186,6 +186,7 @@ async def input_writer(
 
         await ctx.info(f"Case info: {case_info}")
 
+        # Retrieve references
         tutorial_reference, dir_structure, dir_counts_str, allrun_reference, similar_case_advice = retrieve_references(
             case_name=case_info["case_name"],
             case_solver=case_info["case_solver"],


### PR DESCRIPTION
## Summary

The MCP `input_writer` tool currently discards `similar_case_advice` (the 5th return value of `retrieve_references()`), so MCP-driven file generation receives less context than the in-process LangGraph pipeline. This 2-line fix captures and forwards it.

## Background

In the LangGraph pipeline, `planner_node` puts the RAG-derived advice into `state["similar_case_advice"]` and `input_writer_node` forwards it to `initial_write()`:

```python
# src/nodes/input_writer_node.py:85
write_out = initial_write(
    ...
    similar_case_advice=state.get("similar_case_advice"),
    ...
)
```

`initial_write()` then concatenates that advice into the per-file user prompt (`src/services/input_writer.py:124-132, 142`):

```python
advice_text = ""
if isinstance(similar_case_advice, dict):
    advice_text = (
        f"Similar case match level: {similar_case_advice.get('match_level')}\n"
        f"Use scope: {similar_case_advice.get('use_scope')}\n"
        f"Advice: {similar_case_advice.get('advice')}\n"
    )
elif similar_case_advice:
    advice_text = str(similar_case_advice)
...
code_user_prompt = (
    f"User requirement: {user_requirement}\n"
    f"{similar_ref_block}"
    f"{advice_text}"   # <-- empty in MCP path today
    ...
)
```

The MCP `input_writer` tool calls the same `retrieve_references()` (which already produces the advice — see `src/services/plan.py:233`) but throws the 5th return value away with `_`:

```python
# src/mcp/fastmcp_server.py (before this PR)
tutorial_reference, dir_structure, dir_counts_str, allrun_reference, _ = retrieve_references(...)
...
result = await asyncio.to_thread(
    initial_write,
    ...
    # similar_case_advice not passed → defaults to None → advice_text = ""
)
```

So the LLM in MCP mode sees a strictly poorer prompt than in LangGraph mode for the same input.

## Empirical evidence

We observed this on a `buoyantFoam` case (a thermally driven cavity with a hot spot, ~4k cells, OpenFOAM v10). Running the same prompt through both pipelines repeatedly:

| Mode        | `compressible::alphat...` | `div(phi,K)` | `div(phi,Ekp)` | `div(((rho*nuEff)*dev2(T(grad(U)))))` | Pre-run result |
|-------------|---------------------------|--------------|----------------|---------------------------------------|----------------|
| LangGraph   | ✓                         | ✓            | sometimes      | ✓ (compressible form)                 | passes         |
| MCP (today) | inconsistent              | inconsistent | ✗              | ✗ (writes incompressible `muEff` form) | fails          |

Each MCP retry typically fixed one of these and missed another — characteristic whack-a-mole behavior of an LLM operating without enough context. The LangGraph runs were consistently correct because the similar-case advice told the LLM which entries the canonical `tutorials/heatTransfer/buoyantFoam/hotRoom` requires.

## Fix

Two changes in `src/mcp/fastmcp_server.py` `input_writer` tool only:

1. Capture the 5th return value of `retrieve_references()` as `similar_case_advice` instead of `_`.
2. Pass it to `initial_write(..., similar_case_advice=similar_case_advice)`.

```diff
-        # Retrieve references
-        tutorial_reference, dir_structure, dir_counts_str, allrun_reference, _ = retrieve_references(
+        tutorial_reference, dir_structure, dir_counts_str, allrun_reference, similar_case_advice = retrieve_references(
             case_name=case_info["case_name"],
             ...
         )
@@
         result = await asyncio.to_thread(
             initial_write,
             ...
             searchdocs=global_config.searchdocs,
+            similar_case_advice=similar_case_advice,
             progress_callback=progress_callback,
         )
```

No function signature changes, no MCP request/response schema changes. The MCP path now produces the same prompt context as the LangGraph path.

## Test plan

- [x] AST parses cleanly (`python -c "import ast; ast.parse(open('src/mcp/fastmcp_server.py').read())"`)
- [x] Diff is minimal (7 insertions, 2 deletions, all inside `input_writer` tool)
- [x] **Verified end-to-end on `buoyantFoam`**: same prompt that previously failed in MCP mode (5 separate attempts before this fix, all missing one or more required `div` schemes) now consistently produces a complete `system/fvSchemes` with `div(phi,K)`, `div(phi,Ekp)`, the compressible `div(((rho*nuEff)*dev2(T(grad(U)))))` form, and the namespace-prefixed `compressible::alphatJayatillekeWallFunction`. Full 100 s of physical time integrated successfully (output time directories `0/`, `20/`, `40/`, `60/`, `80/`, `100/`). See verification comment below.
- [x] **No regression on non-thermal cases**: ran a 2D incompressible lid-driven cavity (`icoFoam`, 20×20 cells) through MCP mode with the fix applied — completes normally, 37 files / 282 KB output. The `similar_case_advice` for non-thermal cases is now also forwarded but doesn't change correct behavior.

## Notes

- The MCP `plan` tool's `PlanResponse` also drops `similar_case_advice`, but the `input_writer` tool re-runs `retrieve_references()` anyway, so fixing it there is sufficient and doesn't require any schema changes. Plumbing it through the `plan` response could be a follow-up if you want to avoid the duplicate retrieval, but that would require widening `PlanResponse` and `GenerateFilesRequest`.
- Found while debugging a downstream platform integration; happy to provide the case files / logs if you'd like additional reproduction context.
