### PR TITLE
fix: normalize case_dir to absolute path in run_pyvista_script

### DIFF
--- a/src/services/visualization.py
+++ b/src/services/visualization.py
@@ -104,6 +104,7 @@ def run_pyvista_script(
       - If expected_png is provided, we only consider success if that file exists after execution.
       - Apply a timeout so headless/VTK hangs don't block forever.
     """
+    case_dir = os.path.abspath(case_dir)
     script_path = os.path.join(case_dir, filename)
     save_file(script_path, script)
 


### PR DESCRIPTION
Hi,                                                                                                                     
  ## Summary                                                                                                              
                  
  Relative `case_dir` combined with relative `cwd` in `subprocess.run()` caused the                                       
  visualization script path to be resolved twice, doubling the directory segment.
                                                                                                                          
  Using `os.path.abspath()` at function entry follows the same pattern already used                                       
  by `ensure_foam_file()` and `visualization_node()`.                                                                     
                                                                                                                          
  Closes #33                                                                                                              
                                                                                                                          
  ## Test plan                                                                                                            
                  
  - [x] Lid-driven cavity (icoFoam, 20×20) end-to-end: all 7 steps passed including visualization