### PR TITLE
fix(codex): make HTTP timeout configurable (default 300s, was hardcoded 60s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,7 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below, or by adding the volunteer's WeChat account: **ZDSJTUCFD**. The volunteer will invite you to the group.
-
-<p align="center">
-  <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">
-</p>
+Chinese-speaking users can join the Foam-Agent WeChat community by adding the volunteer's WeChat account: **ZDSJTUCFD**. The volunteer will invite you to the group.
 
 ## Citation
 If you use Foam-Agent in your research, please cite our paper:

--- a/README.md
+++ b/README.md
@@ -285,11 +285,7 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below.
-
-<p align="center">
-  <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">
-</p>
+Chinese-speaking users can join the Foam-Agent WeChat community. Since the WeChat group QR code expires periodically, please add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
 
 ## Citation
 If you use Foam-Agent in your research, please cite our paper:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,11 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community. Since the WeChat group QR code expires periodically, please add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
+Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below. Since the WeChat group QR code expires periodically, you can also add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
+
+<p align="center">
+  <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">
+</p>
 
 ## Citation
 If you use Foam-Agent in your research, please cite our paper:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below. Since the WeChat group QR code expires periodically, you can also add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
+Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below, or by adding the volunteer's WeChat account: **ZDSJTUCFD**. The volunteer will invite you to the group.
 
 <p align="center">
   <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">

--- a/src/utils.py
+++ b/src/utils.py
@@ -284,7 +284,15 @@ class _CodexResponsesWrapper:
 
         payload = self._build_payload(messages)
 
-        r = requests.post(url, headers=headers, json=payload, timeout=60, stream=bool(self._stream))
+        # ChatGPT Codex backend can take 60-180s on complex prompts when
+        # reasoning.summary=auto is enabled — the model spends time on the
+        # reasoning trace before emitting tokens. The previous hardcoded 60s
+        # was too tight: prompts with non-trivial BC topology (e.g. a 2-inlet
+        # elbow channel) deterministically exceeded it on gpt-5.5, raising
+        # `HTTPSConnectionPool ... Read timed out. (read timeout=60)` and
+        # failing the workflow. Allow operator override via env var.
+        timeout = int(os.environ.get("FOAMAGENT_HTTP_TIMEOUT", "300"))
+        r = requests.post(url, headers=headers, json=payload, timeout=timeout, stream=bool(self._stream))
 
         # If we get an error, surface the response body to aid debugging.
         if not r.ok:


### PR DESCRIPTION
## Summary

- Replace the hardcoded `timeout=60` in `LLMService`'s custom Codex HTTP client (`src/utils.py:287`) with `int(os.environ.get(\"FOAMAGENT_HTTP_TIMEOUT\", \"300\"))`.
- Pure default-value change with an env-var escape hatch — no protocol or behavior change for prompts that already finish under 60 s.

## Problem

The custom `requests.post()` call to `chatgpt.com/backend-api/codex/responses` had a 60-second read timeout baked in. On complex prompts where the codex backend's `reasoning.summary=\"auto\"` mode (set in `_build_payload`, line 250) spends 30–60 s on the reasoning trace before emitting any tokens, the request exceeds 60 s and `urllib3` severs the connection:

```
HTTPSConnectionPool(host='chatgpt.com', port=443):
Read timed out. (read timeout=60)
During task with name 'planner'
```

This is not a network or rate-limit issue — the codex backend is healthy, the LLM is just thinking. Once the 60 s wall is hit the planner errors out and the whole workflow fails.

## Reproducer (2026-05-23 ~ 2026-05-24 on our CFDQandA platform)

Using each prompt from our public frontend's example set with platform-default `openai-codex/gpt-5.5`, 4 of 5 succeed first-try with **zero retries**; the elbow channel fails deterministically twice:

| Case | BC topology | Result |
|---|---|---|
| lid-driven cavity | 1 movingWall | ✅ 91 s, 3 calls, 0 retries |
| porous blockage | single inlet/outlet | ✅ 167 s, 3 calls, 0 retries |
| hot-room (buoyantFoam) | buoyancy + turbulence | ✅ 227 s, 3 calls, 0 retries |
| **elbow channel** | **2 inlets w/ different vel + pressure outlet** | ❌ 273 s then 280 s, both `read timeout=60` |

Same elbow prompt on a regular OpenAI API key (path that goes through the official `openai-python` SDK with httpx, which has a much higher default read timeout) does not hit this — confirming the cap is the only blocker.

## Fix

```python
# src/utils.py:287
- r = requests.post(url, headers=headers, json=payload, timeout=60, stream=bool(self._stream))
+ timeout = int(os.environ.get(\"FOAMAGENT_HTTP_TIMEOUT\", \"300\"))
+ r = requests.post(url, headers=headers, json=payload, timeout=timeout, stream=bool(self._stream))
```

`300 s` (5 min) is a generous default that covers the longest reasoning traces we've observed while still bounding pathological cases. Operators on slow networks or with even more complex prompts can raise via env var; embedded/CI deployments that want fail-fast can lower.

`import os` was already imported in this file (line 4) so the diff is one effective line.

## Test plan

- [ ] Existing tests pass unchanged (no behavior change for fast prompts).
- [ ] Set `FOAMAGENT_HTTP_TIMEOUT=300` (or unset, since 300 is the new default), re-run the elbow reproducer prompt — should complete successfully on gpt-5.5.
- [ ] Set `FOAMAGENT_HTTP_TIMEOUT=10` and confirm fast-fail behavior on any non-trivial prompt (sanity check that the env var is wired).

## Notes

- Does not touch the other two `requests` calls in `utils.py` (line 519 Ollama health-probe `timeout=2`, line 970 `subprocess.communicate(timeout=max_time_limit)`) — neither has the same problem.
- Does not touch the `httpx`-based OpenAI SDK path used for non-codex providers; their own client already has higher default timeouts.

Closes the codex-side half of issues we've been seeing where users on ChatGPT-subscription plans get spurious planner failures on moderately complex prompts.