### PR TITLE
fix: add prompt constraint for *Final sub-dictionaries in fvSolution

### DIFF
--- a/src/services/input_writer.py
+++ b/src/services/input_writer.py
@@ -149,12 +149,14 @@ def initial_write(
 
         if file_name == "fvSolution":
             code_user_prompt += (
-                "CRITICAL: For pressure-velocity coupling solvers (PISO/PIMPLE), "
-                "the solvers dictionary MUST include "
-                "corresponding *Final sub-dictionaries for each solver entry "
-                "(e.g., pFinal for p, UFinal for U). "
-                "Typically { $<field>; relTol 0; }. "
-                "Also ensure the PIMPLE/PISO sub-dictionary matches the solver's requirement."
+                "\n\nCRITICAL for transient pressure-velocity coupling solvers using PISO/PIMPLE: "
+                "the solvers dictionary must include matching Final solver entries for fields used on the final correction. "
+                "For example, if p is defined, include pFinal { $p; relTol 0; }; "
+                "if U is defined, include UFinal { $U; relTol 0; }. "
+                "For grouped regex entries, use the matching grouped Final entry, e.g. "
+                "\"(U|k|epsilon)Final\" { $U; relTol 0; }. "
+                "Do not emit placeholder text such as $<field>; in the generated file. "
+                "Also ensure the PIMPLE/PISO sub-dictionary matches the selected solver."
             )
 
         if generation_mode == "sequential_dependency" and written_files_ctx:

--- a/src/services/input_writer.py
+++ b/src/services/input_writer.py
@@ -147,6 +147,16 @@ def initial_write(
             "When generating controlDict, do not include anything to preform post processing. Just include the necessary settings to run the simulation."
         )
 
+        if file_name == "fvSolution":
+            code_user_prompt += (
+                "CRITICAL: For pressure-velocity coupling solvers (PISO/PIMPLE), "
+                "the solvers dictionary MUST include "
+                "corresponding *Final sub-dictionaries for each solver entry "
+                "(e.g., pFinal for p, UFinal for U). "
+                "Typically { $<field>; relTol 0; }. "
+                "Also ensure the PIMPLE/PISO sub-dictionary matches the solver's requirement."
+            )
+
         if generation_mode == "sequential_dependency" and written_files_ctx:
             code_user_prompt += (
                 f"The following are files content already generated: {str(written_files_ctx)}\n\n\n"


### PR DESCRIPTION
## Summary

Add explicit prompt constraint in `_build_prompts()` to ensure generated fvSolution includes `*Final` entries (`pFinal`, `UFinal`, etc.) required by PISO/PIMPLE solvers in Foundation OpenFOAM v10.

This addresses the intermittent issue where the LLM omits these entries, causing a startup error that requires the reviewer loop to fix (wasting 1-2 iterations).

## Changes

- `src/services/input_writer.py` — added conditional prompt constraint when `file_name == "fvSolution"`

## Test

Testing with DeepSeek V4-Pro on OpenFOAM v10 shows the fix reduces error correction loops from 1 to 0.

Closes #37