### PR TITLE
feat: add safe existing-case import workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,12 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+
+# Local CFD cases and generated results
+/output-*/
+/bubble_case/
+/cavity_test/
+/openfoam_experiments/
+/foamagent-full-p10.pid
+/user_requirement_p10_smoke*.txt

--- a/README.md
+++ b/README.md
@@ -54,6 +54,44 @@ python foambench_main.py --output ./output --prompt_path ./user_requirement.txt
 
 That's it. Foam-Agent will plan the case, generate all OpenFOAM files, run the simulation, and fix errors automatically.
 
+### 4. Run an Existing Case
+
+An existing case can be supplied instead of a natural-language prompt. This
+mode does not invoke Planner, Meshing, or Input Writer. Instead it enters the
+workflow's protected existing-case branch (`case_import` → shared local runner
+with a controlled-import policy → shared reviewer with a deterministic
+safe-repair policy), preserving the uploaded dictionaries and running a
+validated, controlled equivalent of its `Allrun`.
+
+```bash
+python foambench_main.py \
+  --output ./imported-dam-break \
+  --case_path /path/to/damBreak \
+  --visualize
+```
+
+`--visualize` is optional. When supplied, a successful imported case uses the
+same read-only PyVista visualization node as a prompt-generated case.
+
+`--case_path` accepts either a case directory or a ZIP archive. If an archive
+contains multiple cases, select one explicitly:
+
+```bash
+python foambench_main.py \
+  --output ./imported-case \
+  --case_path ./tutorials.zip \
+  --case_subdir multiphase/interFoam/laminar/damBreak/damBreak
+```
+
+The output directory contains `original/` (a hashed source copy with read-only files),
+`work/` (the only directory executed or repaired), and `report/` (the manifest,
+attempt history, and any diffs). User-provided numeric tokens are never changed
+automatically. The importer only permits a small set of Foundation v10
+utilities/solver commands; custom compilation, dynamic code, ESI cases, and
+unsafe shell setup are reported as blockers rather than executed. If `Allrun`
+is absent, Foam-Agent can infer only the minimal `blockMesh`/`checkMesh`/solver
+plan for a case that already provides enough files.
+
 ## Configuration
 
 All settings live in `src/config.py` with sensible defaults. Every setting can be overridden via environment variables — no need to edit files, especially useful for Docker and CI.
@@ -63,7 +101,7 @@ All settings live in `src/config.py` with sensible defaults. Every setting can b
 | Environment Variable | Purpose | Allowed Values |
 |---|---|---|
 | `FOAMAGENT_MODEL_PROVIDER` | LLM backend | `openai`, `openai-codex`, `anthropic`, `bedrock`, `ollama` |
-| `FOAMAGENT_MODEL_VERSION` | Model identifier | e.g., `gpt-5-mini`, `gpt-5.3-codex`, `claude-opus-4-6` |
+| `FOAMAGENT_MODEL_VERSION` | Model identifier | e.g., `gpt-5-mini`, `gpt-5.6-terra`, `claude-opus-4-6` |
 
 Example:
 ```bash
@@ -229,7 +267,7 @@ If you have a ChatGPT/Codex subscription, you can authenticate via OAuth instead
 ```bash
 docker run -it \
   -e FOAMAGENT_MODEL_PROVIDER=openai-codex \
-  -e FOAMAGENT_MODEL_VERSION=gpt-5.3-codex \
+  -e FOAMAGENT_MODEL_VERSION=gpt-5.6-terra \
   -v ~/.codex/auth.json:/root/.codex/auth.json:ro \
   -p 7860:7860 \
   leoyue123/foamagent

--- a/foambench_main.py
+++ b/foambench_main.py
@@ -22,12 +22,25 @@ def parse_args():
         default=os.path.join(base_dir, "output"),
         help="Base output directory for benchmark results (default: <dir_of_foambench_main.py>/output)"
     )
-    parser.add_argument(
+    input_group = parser.add_mutually_exclusive_group()
+    input_group.add_argument(
         '--prompt_path',
         type=str,
         required=False,
-        default=os.path.join(base_dir, "user_requirement.txt"),
+        default=None,
         help="User requirement file path for the benchmark (default: <dir_of_foambench_main.py>/user_requirement.txt)"
+    )
+    input_group.add_argument(
+        '--case_path',
+        type=str,
+        default=None,
+        help="Existing Foundation OpenFOAM v10 case directory or ZIP archive."
+    )
+    parser.add_argument(
+        '--case_subdir',
+        type=str,
+        default=None,
+        help="Relative case directory inside --case_path when multiple cases are present."
     )
     parser.add_argument(
         '--custom_mesh_path',
@@ -35,30 +48,50 @@ def parse_args():
         default=None,
         help="Path to custom mesh file (e.g., .msh, .stl, .obj). If not provided, no custom mesh will be used."
     )
-    return parser.parse_args()
+    parser.add_argument(
+        '--overwrite_output',
+        action='store_true',
+        help="Explicitly allow replacing an existing non-empty output directory."
+    )
+    parser.add_argument(
+        '--visualize',
+        action='store_true',
+        help="Generate a PyVista visualization after a successful imported case run."
+    )
+    args = parser.parse_args()
+    if args.case_subdir and not args.case_path:
+        parser.error("--case_subdir requires --case_path.")
+    if args.case_path and args.custom_mesh_path:
+        parser.error("--custom_mesh_path is not available with --case_path.")
+    if args.visualize and not args.case_path:
+        parser.error("--visualize requires --case_path.")
+    return args
 
-def run_command(command_str):
+def run_command(command, *, env=None):
     """
     Execute a command string using the current terminal's input/output,
     with the working directory set to the directory of the current file.
     
     Parameters:
-        command_str (str): The command to execute, e.g. "python main.py --output_dir xxxx" 
-                           or "bash xxxxx.sh".
+        command: A command string or an argument sequence, e.g.
+                 ``["python", "main.py", "--output_dir", "xxxx"]``.
+        env: Optional environment overrides for the child workflow process.
     """
-    # Split the command string into a list of arguments
-    args = shlex.split(command_str)
+    # Preserve argument boundaries for paths containing spaces.  Accepting a
+    # string retains compatibility with callers outside this entry point.
+    command_args = shlex.split(command) if isinstance(command, str) else list(command)
     # Set the working directory to the directory of the current file
     cwd = os.path.dirname(os.path.abspath(__file__))
     
     try:
         result = subprocess.run(
-            args,
+            command_args,
             cwd=cwd,
             check=True,
             stdout=sys.stdout,
             stderr=sys.stderr,
-            stdin=sys.stdin
+            stdin=sys.stdin,
+            env=env,
         )
         print(f"Finished command: Return Code {result.returncode}")
     except subprocess.CalledProcessError as e:
@@ -68,19 +101,48 @@ def run_command(command_str):
 def main():
     args = parse_args()
     print(args)
+    base_dir = os.path.dirname(os.path.abspath(__file__))
 
-    # Create the output folder
-    os.makedirs(args.output, exist_ok=True)
+    child_env = os.environ.copy()
+    if args.openfoam_path:
+        openfoam_root = os.path.abspath(os.path.expanduser(args.openfoam_path))
+        bashrc_path = os.path.join(openfoam_root, "etc", "bashrc")
+        if not os.path.isfile(bashrc_path):
+            raise ValueError(
+                "--openfoam_path must point to a Foundation OpenFOAM installation "
+                f"containing etc/bashrc: {openfoam_root}"
+            )
+        child_env["WM_PROJECT_DIR"] = openfoam_root
+        print(f"Using OpenFOAM installation: {openfoam_root}")
 
-    # Build main workflow command with optional custom mesh path
-    main_cmd = f"python src/main.py --prompt_path='{args.prompt_path}' --output_dir='{args.output}'"
+    # Output creation and any overwrite decision are owned by the workflow's
+    # ownership checks before the workflow gets a chance to validate it.
+
+    # Build the workflow invocation as argument tokens, not shell text.
+    main_cmd = [sys.executable, "src/main.py", "--output_dir", args.output]
+    if args.case_path:
+        main_cmd.extend(["--case_path", args.case_path])
+        if args.case_subdir:
+            main_cmd.extend(["--case_subdir", args.case_subdir])
+        if args.visualize:
+            main_cmd.append("--visualize")
+    else:
+        prompt_path = args.prompt_path or os.path.join(base_dir, "user_requirement.txt")
+        main_cmd.extend(["--prompt_path", prompt_path])
     if args.custom_mesh_path:
-        main_cmd += f" --custom_mesh_path='{args.custom_mesh_path}'"
+        main_cmd.extend(["--custom_mesh_path", args.custom_mesh_path])
+    if args.overwrite_output:
+        main_cmd.append("--overwrite_output")
     
-    print(f"Main workflow command: {main_cmd}")
+    print(f"Main workflow command: {shlex.join(main_cmd)}")
     
     print("Starting workflow...")
-    run_command(main_cmd)
+    if args.openfoam_path:
+        run_command(main_cmd, env=child_env)
+    else:
+        # Preserve the original call shape for wrappers which replace
+        # ``run_command`` and do not need an environment override.
+        run_command(main_cmd)
     print("Workflow command finished.")
 
 if __name__ == "__main__":
@@ -88,4 +150,6 @@ if __name__ == "__main__":
     #   python foambench_main.py
     #   python foambench_main.py --output output --prompt_path user_requirement.txt
     #   python foambench_main.py --output output --prompt_path user_requirement.txt --custom_mesh_path my_mesh.msh
+    #   python foambench_main.py --output imported --case_path ./existing_case
+    #   python foambench_main.py --output imported --case_path ./existing_case --visualize
     main()

--- a/foambench_main.py
+++ b/foambench_main.py
@@ -67,7 +67,7 @@ def parse_args():
         parser.error("--visualize requires --case_path.")
     return args
 
-def run_command(command, *, env=None):
+def run_command(command, *, env=None, openfoam_bashrc=None):
     """
     Execute a command string using the current terminal's input/output,
     with the working directory set to the directory of the current file.
@@ -76,6 +76,9 @@ def run_command(command, *, env=None):
         command: A command string or an argument sequence, e.g.
                  ``["python", "main.py", "--output_dir", "xxxx"]``.
         env: Optional environment overrides for the child workflow process.
+        openfoam_bashrc: Optional OpenFOAM bashrc to source before starting
+            the workflow. This makes preprocessing tools such as gmshToFoam
+            available to the Python child, not just its later Allrun script.
     """
     # Preserve argument boundaries for paths containing spaces.  Accepting a
     # string retains compatibility with callers outside this entry point.
@@ -83,6 +86,16 @@ def run_command(command, *, env=None):
     # Set the working directory to the directory of the current file
     cwd = os.path.dirname(os.path.abspath(__file__))
     
+    if openfoam_bashrc:
+        command_args = [
+            "bash",
+            "-c",
+            'source "$1" && shift && exec "$@"',
+            "foamagent-benchmark",
+            openfoam_bashrc,
+            *command_args,
+        ]
+
     try:
         result = subprocess.run(
             command_args,
@@ -104,10 +117,11 @@ def main():
     base_dir = os.path.dirname(os.path.abspath(__file__))
 
     child_env = os.environ.copy()
+    openfoam_bashrc = None
     if args.openfoam_path:
         openfoam_root = os.path.abspath(os.path.expanduser(args.openfoam_path))
-        bashrc_path = os.path.join(openfoam_root, "etc", "bashrc")
-        if not os.path.isfile(bashrc_path):
+        openfoam_bashrc = os.path.join(openfoam_root, "etc", "bashrc")
+        if not os.path.isfile(openfoam_bashrc):
             raise ValueError(
                 "--openfoam_path must point to a Foundation OpenFOAM installation "
                 f"containing etc/bashrc: {openfoam_root}"
@@ -138,7 +152,7 @@ def main():
     
     print("Starting workflow...")
     if args.openfoam_path:
-        run_command(main_cmd, env=child_env)
+        run_command(main_cmd, env=child_env, openfoam_bashrc=openfoam_bashrc)
     else:
         # Preserve the original call shape for wrappers which replace
         # ``run_command`` and do not need an environment override.

--- a/scripts/scan_case_import_matrix.py
+++ b/scripts/scan_case_import_matrix.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Scan a Foundation tutorial tree through Foam-Agent's import preflight.
+
+The script deliberately calls :func:`import_case` only: every candidate is
+copied into an isolated temporary output, validated, and represented by a
+manifest, but no solver is launched.  It is useful in Docker/CI to measure
+which upstream tutorial shapes are accepted by the intentionally restricted
+case-import policy.
+
+Example::
+
+    source /opt/openfoam10/etc/bashrc
+    python scripts/scan_case_import_matrix.py --tutorial-root "$FOAM_TUTORIALS"
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from services.case_import import CaseImportError, import_case  # noqa: E402
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preflight all OpenFOAM tutorials through safe case-import mode."
+    )
+    parser.add_argument(
+        "--tutorial-root",
+        type=Path,
+        default=os.environ.get("FOAM_TUTORIALS"),
+        help="Tutorial root (defaults to $FOAM_TUTORIALS).",
+    )
+    parser.add_argument(
+        "--max-cases",
+        type=int,
+        default=0,
+        help="Optional positive cap for a quick smoke scan; 0 scans every case.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path for the machine-readable report.",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Print aggregate counts only (the optional JSON report remains complete).",
+    )
+    return parser.parse_args()
+
+
+def _tutorial_root(args: argparse.Namespace) -> Path | None:
+    if args.tutorial_root is None:
+        print("--tutorial-root is required when FOAM_TUTORIALS is not set.", file=sys.stderr)
+        return None
+    if args.max_cases < 0:
+        print("--max-cases must be zero or positive.", file=sys.stderr)
+        return None
+    tutorial_root = args.tutorial_root.expanduser().resolve()
+    if not tutorial_root.is_dir():
+        print(f"Tutorial root is not a directory: {tutorial_root}", file=sys.stderr)
+        return None
+    return tutorial_root
+
+
+def _tutorial_cases(tutorial_root: Path, max_cases: int) -> list[Path]:
+    cases = sorted(
+        control.parent.parent
+        for control in tutorial_root.rglob("controlDict")
+        if control.parent.name == "system" and control.is_file()
+    )
+    return cases[:max_cases] if max_cases else cases
+
+
+def _scan_cases(tutorial_root: Path, cases: list[Path]) -> dict[str, Any]:
+    outcomes: Counter[str] = Counter()
+    blocking_reasons: Counter[str] = Counter()
+    rejected: list[dict[str, str]] = []
+    supported: list[str] = []
+    blocked: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="foamagent-import-matrix-") as scratch:
+        scratch_root = Path(scratch)
+        for index, case in enumerate(cases, start=1):
+            relative = case.relative_to(tutorial_root).as_posix()
+            try:
+                manifest = import_case(case, scratch_root / f"case-{index}")
+            except CaseImportError as exc:
+                outcomes["rejected"] += 1
+                rejected.append({"case": relative, "error": str(exc)})
+                continue
+            if manifest.supported:
+                outcomes["supported"] += 1
+                supported.append(relative)
+                continue
+            outcomes["blocked"] += 1
+            for issue in manifest.blocking_issues:
+                blocking_reasons[issue] += 1
+            blocked.append({"case": relative, "issues": manifest.blocking_issues})
+    return {
+        "tutorial_root": str(tutorial_root),
+        "cases_scanned": len(cases),
+        "outcomes": dict(outcomes),
+        "blocking_reason_counts": dict(blocking_reasons.most_common()),
+        "supported": supported,
+        "blocked": blocked,
+        "rejected": rejected,
+    }
+
+
+def _write_report(report: dict[str, Any], args: argparse.Namespace) -> None:
+    visible_keys = (
+        "tutorial_root",
+        "cases_scanned",
+        "outcomes",
+        "blocking_reason_counts",
+    )
+    printable_report = {key: report[key] for key in visible_keys} if args.summary_only else report
+    print(json.dumps(printable_report, indent=2, ensure_ascii=False))
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+def main() -> int:
+    args = _parse_args()
+    tutorial_root = _tutorial_root(args)
+    if tutorial_root is None:
+        return 2
+
+    report = _scan_cases(tutorial_root, _tutorial_cases(tutorial_root, args.max_cases))
+    _write_report(report, args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,7 @@ class Config:
     database_path: str = Path(__file__).resolve().parent.parent / "database"
     run_directory: str = Path(__file__).resolve().parent.parent / "runs"
     case_dir: str = ""
+    overwrite_case_dir: bool = False
     max_time_limit: int = 3600  # Max time limit after which the openfoam run will be terminated, in seconds
     recursion_limit: int = 100  # LangGraph recursion limit
     # Input writer generation mode:
@@ -32,11 +33,11 @@ class Config:
     model_provider: str = "openai-codex"  # [openai, openai-codex, ollama, bedrock, anthropic, deepseek]
     # model_version examples:
     # - OpenAI: "gpt-5-mini"
-    # - OpenAI Codex subscription: "gpt-5.3-codex" (or whichever Codex model you have access to)
+    # - OpenAI Codex subscription: "gpt-5.6-terra" (or whichever Codex model you have access to)
     # - Ollama: "qwen2.5:32b-instruct"
     # - Bedrock: application inference profile ARN
     # - Anthropic: claude-3-5-sonnet-latest
-    model_version: str = "gpt-5.3-codex"
+    model_version: str = "gpt-5.6-terra"
     temperature: float = 1
     openfoam_fork: str = "foundation"  # Default to Foundation v10
     

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,5 @@
-from dataclasses import dataclass, field
-from typing import List, Optional, TypedDict, Literal
+from typing import Optional
 from langgraph.graph import StateGraph, START, END
-from langgraph.types import Command
 import argparse
 from pathlib import Path
 from utils import LLMService, GraphState
@@ -14,14 +12,24 @@ from nodes.local_runner_node import local_runner_node
 from nodes.reviewer_node import reviewer_node
 from nodes.visualization_node import visualization_node
 from nodes.hpc_runner_node import hpc_runner_node
+from nodes.imported_case_node import case_import_node
 from router_func import (
+    route_after_case_import,
+    route_after_meshing,
     route_after_planner,
     route_after_input_writer,
     route_after_runner,
-    route_after_reviewer
+    route_after_reviewer,
+    route_workflow_entry,
 )
 from logger import close_logging
 import json
+
+
+def workflow_entry_node(_state: GraphState) -> dict:
+    """Provide one graph entry point before routing by input mode."""
+    return {}
+
 
 def create_foam_agent_graph() -> StateGraph:
     """Create the OpenFOAM agent workflow graph."""
@@ -30,6 +38,7 @@ def create_foam_agent_graph() -> StateGraph:
     workflow = StateGraph(GraphState)
     
     # Add nodes
+    workflow.add_node("entry", workflow_entry_node)
     workflow.add_node("planner", planner_node)
     workflow.add_node("meshing", meshing_node)
     workflow.add_node("input_writer", input_writer_node)
@@ -37,21 +46,44 @@ def create_foam_agent_graph() -> StateGraph:
     workflow.add_node("hpc_runner", hpc_runner_node)
     workflow.add_node("reviewer", reviewer_node)
     workflow.add_node("visualization", visualization_node)
+    workflow.add_node("case_import", case_import_node)
     
     # Add edges
-    workflow.add_edge(START, "planner")
+    workflow.add_edge(START, "entry")
+    workflow.add_conditional_edges("entry", route_workflow_entry)
     workflow.add_conditional_edges("planner", route_after_planner)
-    workflow.add_edge("meshing", "input_writer")
+    workflow.add_conditional_edges("meshing", route_after_meshing)
     workflow.add_conditional_edges("input_writer", route_after_input_writer)
     workflow.add_conditional_edges("hpc_runner", route_after_runner)
     workflow.add_conditional_edges("local_runner", route_after_runner)
     workflow.add_conditional_edges("reviewer", route_after_reviewer)
+    workflow.add_conditional_edges("case_import", route_after_case_import)
     workflow.add_edge("visualization", END)
     
     return workflow
 
-def initialize_state(user_requirement: str, config: Config, custom_mesh_path: Optional[str] = None) -> GraphState:
-    case_stats = json.load(open(f"{config.database_path}/raw/openfoam_case_stats.json", "r"))
+def initialize_state(
+    user_requirement: str,
+    config: Config,
+    custom_mesh_path: Optional[str] = None,
+    *,
+    workflow_mode: str = "prompt",
+    case_import_path: Optional[str] = None,
+    case_import_subdir: Optional[str] = None,
+    requires_visualization: Optional[bool] = None,
+) -> GraphState:
+    """Build the state for either prompt generation or controlled case import.
+
+    Import mode intentionally avoids loading RAG metadata or constructing an
+    LLM client: neither is needed to execute a user-provided case safely.
+    """
+    case_stats = None
+    llm_service = None
+    if workflow_mode == "prompt":
+        case_stats_path = Path(config.database_path) / "raw" / "openfoam_case_stats.json"
+        with case_stats_path.open(encoding="utf-8") as case_stats_file:
+            case_stats = json.load(case_stats_file)
+        llm_service = LLMService(config)
     # mesh_type = "custom_mesh" if custom_mesh_path else "standard_mesh"
     state = GraphState(
         user_requirement=user_requirement,
@@ -64,7 +96,7 @@ def initialize_state(user_requirement: str, config: Config, custom_mesh_path: Op
         error_command=None,
         error_content=None,
         loop_count=0,
-        llm_service=LLMService(config),
+        llm_service=llm_service,
         case_stats=case_stats,
         tutorial_reference=None,
         case_path_reference=None,
@@ -88,11 +120,30 @@ def initialize_state(user_requirement: str, config: Config, custom_mesh_path: Op
         rewrite_plan=None,
         input_writer_mode="initial",
         requires_hpc=None,
-        requires_visualization=None,
+        requires_visualization=requires_visualization,
         job_id=None,
         cluster_info=None,
         slurm_script_path=None,
-        termination_reason=None
+        termination_reason=None,
+        workflow_mode=workflow_mode,
+        # These policies make the common execution/review nodes explicit about
+        # what they may do.  ``workflow_mode`` remains the entry router's
+        # concern; downstream nodes use policy, not the input transport.
+        execution_policy=(
+            "generated_allrun" if workflow_mode == "prompt" else "controlled_import"
+        ),
+        repair_policy=(
+            "llm_rewrite" if workflow_mode == "prompt" else "numeric_invariant_only"
+        ),
+        case_import_path=case_import_path,
+        case_import_subdir=case_import_subdir,
+        case_import_manifest=None,
+        case_import_original_dir=None,
+        case_import_report_dir=None,
+        case_import_attempts=[],
+        case_import_overrides={},
+        case_import_error_fingerprints=[],
+        case_import_status=None,
     )
     if custom_mesh_path:
         print(f"<custom_mesh_path>{custom_mesh_path}</custom_mesh_path>")
@@ -100,7 +151,7 @@ def initialize_state(user_requirement: str, config: Config, custom_mesh_path: Op
         print("<custom_mesh_path>None</custom_mesh_path>")
     return state
 
-def main(user_requirement: str, config: Config, custom_mesh_path: Optional[str] = None):
+def main(user_requirement: str, config: Config, custom_mesh_path: Optional[str] = None) -> GraphState:
     """Main function to run the OpenFOAM workflow."""
     
     # Create and compile the graph
@@ -114,6 +165,9 @@ def main(user_requirement: str, config: Config, custom_mesh_path: Optional[str] 
 
     # Invoke the graph
     try:
+        # Every graph node passes this invocation's LLM service explicitly to
+        # its service-layer operation.  This keeps concurrent configurations
+        # isolated instead of relying on mutable process-wide state.
         result = app.invoke(initial_state, config={"recursion_limit": config.recursion_limit})
 
         termination_reason = result.get("termination_reason")
@@ -126,9 +180,65 @@ def main(user_requirement: str, config: Config, custom_mesh_path: Optional[str] 
         if result.get("llm_service"):
             result["llm_service"].print_statistics()
 
+        return result
+
     except Exception as e:
         print(f"<workflow_error>{e}</workflow_error>")
         raise
+    finally:
+        close_logging()
+
+
+def main_imported_case(
+    case_path: str,
+    config: Config,
+    *,
+    case_subdir: Optional[str] = None,
+    visualize: bool = False,
+) -> dict:
+    """Run an existing case through the protected branch of the StateGraph.
+
+    The branch omits Planner, Meshing, Input Writer, and the LLM reviewer so
+    user dictionaries cannot be regenerated or numerically modified.
+    """
+
+    if not config.case_dir:
+        raise ValueError("--output_dir is required when --case_path is used.")
+    try:
+        workflow = create_foam_agent_graph()
+        app = workflow.compile()
+        initial_state = initialize_state(
+            "Run the supplied OpenFOAM case without changing user-provided numeric inputs.",
+            config,
+            workflow_mode="imported_case",
+            case_import_path=case_path,
+            case_import_subdir=case_subdir,
+            requires_visualization=visualize,
+        )
+        print("<workflow_start>Starting imported-case Foam-Agent workflow...</workflow_start>")
+        final_state = app.invoke(
+            initial_state,
+            config={"recursion_limit": config.recursion_limit},
+        )
+        manifest = final_state.get("case_import_manifest")
+        errors = final_state.get("error_logs") or []
+        result = {
+            "status": final_state.get("case_import_status", "blocked"),
+            "original_dir": final_state.get("case_import_original_dir"),
+            "work_dir": final_state.get("case_dir"),
+            "report_dir": final_state.get("case_import_report_dir"),
+            "manifest": manifest.to_dict() if manifest is not None else None,
+            "attempts": final_state.get("case_import_attempts") or [],
+            "errors": errors,
+        }
+        summary = {
+            "status": result["status"],
+            "work_dir": result["work_dir"],
+            "report_dir": result["report_dir"],
+            "attempt_count": len(result["attempts"]),
+        }
+        print(f"<case_import_result>{json.dumps(summary)}</case_import_result>")
+        return result
     finally:
         close_logging()
 
@@ -137,11 +247,30 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run the OpenFOAM workflow"
     )
-    parser.add_argument(
+    input_group = parser.add_mutually_exclusive_group()
+    input_group.add_argument(
         "--prompt_path",
         type=str,
-        default=f"{Path(__file__).parent.parent}/user_requirement.txt",
+        default=None,
         help="User requirement file path for the workflow.",
+    )
+    input_group.add_argument(
+        "--case_path",
+        type=str,
+        default=None,
+        help=(
+            "Existing Foundation OpenFOAM v10 case directory or ZIP archive. "
+            "This bypasses prompt generation and runs only validated case commands."
+        ),
+    )
+    parser.add_argument(
+        "--case_subdir",
+        type=str,
+        default=None,
+        help=(
+            "Relative case directory inside --case_path when an archive or "
+            "directory contains more than one system/controlDict."
+        ),
     )
     parser.add_argument(
         "--output_dir",
@@ -164,6 +293,16 @@ if __name__ == "__main__":
             "If a file exists at <reuse_generated_dir>/<folder>/<file>, Foam-Agent will copy it into the current output and skip generation for that file."
         ),
     )
+    parser.add_argument(
+        "--overwrite_output",
+        action="store_true",
+        help="Explicitly allow replacing an existing non-empty output directory.",
+    )
+    parser.add_argument(
+        "--visualize",
+        action="store_true",
+        help="Generate a PyVista visualization after a successful imported case run.",
+    )
     
     args = parser.parse_args()
     print(f"args: {args}")
@@ -178,8 +317,33 @@ if __name__ == "__main__":
 
     if args.reuse_generated_dir:
         config.reuse_generated_dir = args.reuse_generated_dir
+
+    config.overwrite_case_dir = args.overwrite_output
     
-    with open(args.prompt_path, 'r') as f:
-        user_requirement = f.read()
-    
-    main(user_requirement, config, args.custom_mesh_path)
+    if args.case_path:
+        if args.custom_mesh_path:
+            parser.error("--custom_mesh_path is not available with --case_path.")
+        if args.reuse_generated_dir:
+            parser.error("--reuse_generated_dir is not available with --case_path.")
+        if not args.output_dir:
+            parser.error("--output_dir is required with --case_path.")
+        imported_result = main_imported_case(
+            args.case_path,
+            config,
+            case_subdir=args.case_subdir,
+            visualize=args.visualize,
+        )
+        if imported_result.get("status") != "success":
+            raise SystemExit(2)
+    else:
+        if args.case_subdir:
+            parser.error("--case_subdir requires --case_path.")
+        if args.visualize:
+            parser.error("--visualize requires --case_path.")
+        prompt_path = args.prompt_path or f"{Path(__file__).parent.parent}/user_requirement.txt"
+        with open(prompt_path, 'r') as f:
+            user_requirement = f.read()
+
+        final_state = main(user_requirement, config, args.custom_mesh_path)
+        if final_state.get("termination_reason") == "max_review_loop_reached":
+            raise SystemExit(2)

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,11 @@ def workflow_entry_node(_state: GraphState) -> dict:
     return {}
 
 
+def workflow_exit_code(state: GraphState) -> int:
+    """Return a process exit code for a graph state with a terminal failure."""
+    return 2 if state.get("termination_reason") else 0
+
+
 def create_foam_agent_graph() -> StateGraph:
     """Create the OpenFOAM agent workflow graph."""
     
@@ -171,8 +176,11 @@ def main(user_requirement: str, config: Config, custom_mesh_path: Optional[str] 
         result = app.invoke(initial_state, config={"recursion_limit": config.recursion_limit})
 
         termination_reason = result.get("termination_reason")
-        if termination_reason == "max_review_loop_reached":
-            print("<workflow_end>Workflow finished after reaching the maximum review loop limit.</workflow_end>")
+        if termination_reason:
+            print(
+                "<workflow_end>Workflow stopped without completing successfully: "
+                f"{termination_reason}</workflow_end>"
+            )
         else:
             print("<workflow_end>Workflow completed successfully!</workflow_end>")
 
@@ -345,5 +353,5 @@ if __name__ == "__main__":
             user_requirement = f.read()
 
         final_state = main(user_requirement, config, args.custom_mesh_path)
-        if final_state.get("termination_reason") == "max_review_loop_reached":
-            raise SystemExit(2)
+        if exit_code := workflow_exit_code(final_state):
+            raise SystemExit(exit_code)

--- a/src/mcp/fastmcp_server.py
+++ b/src/mcp/fastmcp_server.py
@@ -7,14 +7,13 @@ exposing OpenFOAM simulation capabilities through clean, well-typed interfaces.
 import asyncio
 import os
 import json
-from typing import Dict, List, Optional, Any
+from typing import Dict, List
 
 from fastmcp import FastMCP, Context
 from pydantic import BaseModel, Field
 
 # Import existing services
 import sys
-import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from services.plan import (
@@ -28,12 +27,8 @@ from services.run_local import run_allrun_and_collect_errors
 from utils import FoamPydantic, read_case_foamfiles, scan_case_directory
 from services.review import review_error_logs
 from translation.esi_translator import convert_case_to_esi_if_needed
-from services.visualization import (
-    ensure_foam_file,
-    generate_pyvista_script,
-    run_pyvista_script,
-    fix_pyvista_script
-)
+from services.visualization import visualize_case
+from services.output_safety import prepare_output_directory
 from config import Config
 
 
@@ -133,6 +128,10 @@ class GenerateFilesRequest(BaseModel):
     case_solver: str = Field(description="OpenFOAM solver to use")
     case_domain: str = Field(description="Simulation domain")
     case_category: str = Field(description="Case category")
+    overwrite_output: bool = Field(
+        default=False,
+        description="Allow replacing an existing Foam-Agent-owned output directory.",
+    )
 
 
 class GenerateFilesResponse(BaseModel):
@@ -163,6 +162,7 @@ async def input_writer(
             case_dir="",
             run_times=global_config.run_times
         )
+        prepare_output_directory(case_dir, overwrite=request.overwrite_output)
 
         await ctx.info(f"Case directory: {case_dir}")
 
@@ -582,27 +582,18 @@ async def visualization(
         if not os.path.exists(request.case_dir):
             raise ValueError(f"Case directory does not exist: {request.case_dir}")
         
-        # Ensure foam file exists
-        foam_file = ensure_foam_file(request.case_dir)
-        
-        # Generate visualization script
-        script = generate_pyvista_script(
-            case_dir=request.case_dir,
-            foam_file=foam_file,
-            user_requirement=request.quantity,
-            previous_errors=[]
+        result = await asyncio.to_thread(
+            visualize_case,
+            request.case_dir,
+            request.quantity,
+            max_loop=max(1, min(global_config.max_loop, 2)),
+            timeout_s=max(1, min(global_config.max_time_limit, 180)),
         )
-        
-        # Run visualization script
-        ok, img, errs = run_pyvista_script(request.case_dir, script)
-        
-        if ok and img:
-            artifacts = [img]
-        else:
-            # Try to fix the script
-            fixed = fix_pyvista_script(foam_file, script, errs)
-            ok2, img2, errs2 = run_pyvista_script(request.case_dir, fixed)
-            artifacts = [img2] if ok2 and img2 else []
+        visualization_result = result["pyvista_visualization"]
+        if not visualization_result["success"]:
+            raise RuntimeError(visualization_result["error"])
+        artifacts = result["plot_outputs"]
+        script = visualization_result["script"]
         
         await ctx.info(f"Generated {len(artifacts)} visualization artifact(s)")
         

--- a/src/nodes/hpc_runner_node.py
+++ b/src/nodes/hpc_runner_node.py
@@ -22,6 +22,7 @@ def hpc_runner_node(state):
     """
     config = state["config"]
     case_dir = state["case_dir"]
+    llm_service = state.get("llm_service")
     allrun_file_path = os.path.join(case_dir, "Allrun")
     max_loop = config.max_loop
     current_attempt = 0
@@ -38,7 +39,11 @@ def hpc_runner_node(state):
     
     # Extract cluster information using service
     print("Extracting cluster information from user requirement...")
-    cluster_info = extract_cluster_info_from_requirement(state["user_requirement"], case_dir)
+    cluster_info = extract_cluster_info_from_requirement(
+        state["user_requirement"],
+        case_dir,
+        llm_service=llm_service,
+    )
     print(f"<cluster_info>{cluster_info}</cluster_info>")
     
     # Submit the job with retry logic
@@ -49,7 +54,11 @@ def hpc_runner_node(state):
         # Create SLURM script
         if current_attempt == 1:
             print("Creating initial SLURM script...")
-            script_path = create_slurm_script(case_dir, cluster_info)
+            script_path = create_slurm_script(
+                case_dir,
+                cluster_info,
+                llm_service=llm_service,
+            )
         else:
             print(f"Regenerating SLURM script based on previous error...")
             try:
@@ -58,7 +67,13 @@ def hpc_runner_node(state):
             except Exception:
                 prev = ""
             # Use service helper for regeneration
-            script_path = create_slurm_script_with_error_context(case_dir, cluster_info, last_error_msg, prev)
+            script_path = create_slurm_script_with_error_context(
+                case_dir,
+                cluster_info,
+                last_error_msg,
+                prev,
+                llm_service=llm_service,
+            )
         
         print(f"SLURM script created at: {script_path}")
         

--- a/src/nodes/imported_case_node.py
+++ b/src/nodes/imported_case_node.py
@@ -1,0 +1,147 @@
+"""Imported-case preparation plus adapters used by common workflow nodes.
+
+This branch deliberately never calls Planner, Meshing, Input Writer, or the
+LLM reviewer.  An imported case is user-owned input: its dictionaries are
+executed only through a validated command plan, and retries may apply only the
+deterministic numeric-invariant repairs defined by ``case_import_repairs``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from logger import log_review, setup_logging
+from services.case_import import (
+    CaseImportError,
+    execute_imported_case,
+    execute_imported_case_attempt,
+    import_case,
+    prepare_imported_work_tree,
+    repair_imported_case_attempt,
+    write_import_attempt_report,
+)
+
+
+def case_import_node(state: dict[str, Any]) -> dict[str, Any]:
+    """Validate and materialise an input case without running user shell code."""
+    print("<case_import>")
+    try:
+        manifest = import_case(
+            state["case_import_path"],
+            state["config"].case_dir,
+            case_subdir=state.get("case_import_subdir"),
+            overwrite=state["config"].overwrite_case_dir,
+        )
+    except CaseImportError as exc:
+        error = {"file": "case_import", "error_content": str(exc)}
+        print(f"<case_import_error>{exc}</case_import_error>")
+        print("</case_import>")
+        return {
+            "case_import_status": "blocked",
+            "error_logs": [error],
+            "termination_reason": "case_import_blocked",
+        }
+
+    original_dir = Path(manifest.output_root) / "original"
+    work_dir = Path(manifest.output_root) / "work"
+    report_dir = Path(manifest.output_root) / "report"
+    setup_logging(str(report_dir))
+    print(f"<platform>{manifest.platform}</platform>")
+    print(f"<application>{manifest.application}</application>")
+    print(f"<allrun_provided>{manifest.allrun_provided}</allrun_provided>")
+    print("</case_import>")
+
+    requested_visualization = state.get("requires_visualization") is True
+    base_result = {
+        "case_import_manifest": manifest,
+        "case_import_original_dir": str(original_dir),
+        "case_import_report_dir": str(report_dir),
+        "case_import_attempts": [],
+        "case_import_overrides": {},
+        "case_import_error_fingerprints": [],
+        "case_dir": str(work_dir),
+        "case_name": Path(manifest.case_root).name or manifest.application,
+        "case_solver": manifest.application,
+        # The common runner/reviewer route by these explicit policies, rather
+        # than by the fact that this case happened to come from a CLI import.
+        "execution_policy": "controlled_import",
+        "repair_policy": "numeric_invariant_only",
+        # Imported execution is local. Visualization is explicitly requested
+        # only and uses the deterministic renderer on the disposable work copy;
+        # it never invokes the LLM fallback or changes original inputs.
+        "requires_hpc": False,
+        "requires_visualization": requested_visualization,
+    }
+    if not manifest.supported:
+        errors = [
+            {"file": "case_manifest", "error_content": issue}
+            for issue in manifest.blocking_issues
+        ]
+        write_import_attempt_report(report_dir, [])
+        log_review(str(errors), "case_import_blockers")
+        return {
+            **base_result,
+            "case_import_status": "blocked",
+            "error_logs": errors,
+            "termination_reason": "case_import_blocked",
+        }
+
+    prepare_imported_work_tree(work_dir)
+    return {**base_result, "case_import_status": "ready", "error_logs": []}
+
+
+def run_imported_case_attempt(state: dict[str, Any]) -> dict[str, Any]:
+    """Execute one controlled import attempt for the common runner node."""
+    print("<imported_case_runner>")
+    result = execute_imported_case_attempt(
+        state["case_import_manifest"],
+        original_dir=state["case_import_original_dir"],
+        work_dir=state["case_dir"],
+        report_dir=state["case_import_report_dir"],
+        attempts=state.get("case_import_attempts") or [],
+        overrides=state.get("case_import_overrides") or {},
+        timeout=state["config"].max_time_limit,
+        executor=execute_imported_case,
+    )
+    print("</imported_case_runner>")
+    if result["errors"]:
+        log_review(str(result["errors"]), "error_logs")
+    return {
+        "case_import_attempts": result["attempts"],
+        "case_import_status": result["status"],
+        "error_logs": result["errors"],
+    }
+
+
+def repair_imported_case(state: dict[str, Any]) -> dict[str, Any]:
+    """Apply an error-gated safe repair for the common reviewer node."""
+    errors = list(state.get("error_logs") or [])
+    if not errors:
+        return {"case_import_status": "success"}
+
+    print("<imported_case_reviewer>")
+    result = repair_imported_case_attempt(
+        original_dir=state["case_import_original_dir"],
+        work_dir=state["case_dir"],
+        report_dir=state["case_import_report_dir"],
+        attempts=state.get("case_import_attempts") or [],
+        errors=errors,
+        error_fingerprints=state.get("case_import_error_fingerprints") or [],
+        loop_count=state.get("loop_count", 0),
+        max_repairs=state["config"].max_loop,
+    )
+    print("</imported_case_reviewer>")
+    if "repairs" in result:
+        log_review(str(result["repairs"]), "safe_import_repairs")
+    update = {
+        "case_import_attempts": result["attempts"],
+        "case_import_error_fingerprints": result["error_fingerprints"],
+        "case_import_status": result["status"],
+    }
+    if result["status"] == "ready":
+        update["case_import_overrides"] = result["overrides"]
+        update["loop_count"] = result["loop_count"]
+    elif result.get("termination_reason"):
+        update["termination_reason"] = result["termination_reason"]
+    return update

--- a/src/nodes/input_writer_node.py
+++ b/src/nodes/input_writer_node.py
@@ -1,39 +1,8 @@
-# input_writer_node.py
-import os
-from utils import save_file, parse_context, retrieve_faiss, FoamPydantic, FoamfilePydantic, read_case_foamfiles, scan_case_directory
+"""Thin LangGraph adapter for OpenFOAM input generation and rewriting."""
+
+from utils import read_case_foamfiles, scan_case_directory
 from services.input_writer import initial_write, build_allrun, rewrite_files
 from translation.esi_translator import convert_case_to_esi_if_needed
-import re
-from typing import List
-from pydantic import BaseModel, Field
-
-# System prompts for different modes
-INITIAL_WRITE_SYSTEM_PROMPT = (
-    "You are an expert in OpenFOAM simulation and numerical modeling."
-    f"Your task is to generate a complete and functional file named: <file_name>{{file_name}}</file_name> within the <folder_name>{{folder_name}}</folder_name> directory. "
-    "Ensure all required values are present and match with the files content already generated."
-    "Before finalizing the output, ensure:\n"
-    "- All necessary fields exist (e.g., if `nu` is defined in `constant/transportProperties`, it must be used correctly in `0/U`).\n"
-    "- Cross-check field names between different files to avoid mismatches.\n"
-    "- Ensure units and dimensions are correct** for all physical variables.\n"
-    f"- Ensure case solver settings are consistent with the user's requirements. Available solvers are: {{case_solver}}.\n"
-    "Provide only the code—no explanations, comments, or additional text."
-)
-        
-
-def parse_allrun(text: str) -> str:
-    match = re.search(r'```(.*?)```', text, re.DOTALL)
-    
-    return match.group(1).strip() 
-
-def retrieve_commands(command_path) -> str:
-    with open(command_path, 'r') as file:
-        commands = file.readlines()
-    
-    return f"[{', '.join([command.strip() for command in commands])}]"
-    
-class CommandsPydantic(BaseModel):
-    commands: List[str] = Field(description="List of commands")
 
 def input_writer_node(state):
     """
@@ -65,6 +34,9 @@ def _rewrite_mode(state):
         user_requirement=state.get("user_requirement", ""),
         foamfiles=state.get("foamfiles"),
         dir_structure=state.get("dir_structure", {}),
+        openfoam_fork=getattr(state["config"], "openfoam_fork", "foundation"),
+        case_solver=state.get("case_solver", ""),
+        llm_service=state.get("llm_service"),
     )
     print("</input_writer>")
     
@@ -88,10 +60,13 @@ def _initial_write_mode(state):
         subtasks=state["subtasks"],
         user_requirement=state["user_requirement"],
         tutorial_reference=state["tutorial_reference"],
-        case_solver=state['case_stats']['case_solver'],
+        case_solver=state["case_solver"],
+        openfoam_fork=getattr(config, "openfoam_fork", "foundation"),
         generation_mode=getattr(config, "input_writer_generation_mode", "sequential_dependency"),
         similar_case_advice=state.get("similar_case_advice"),
         reuse_generated_dir=getattr(config, "reuse_generated_dir", ""),
+        llm_service=state.get("llm_service"),
+        config=config,
     )
 
     dir_structure = write_out["dir_structure"]
@@ -109,6 +84,9 @@ def _initial_write_mode(state):
         allrun_reference=state["allrun_reference"],
         mesh_type=mesh_type,
         mesh_commands=mesh_commands,
+        user_requirement=state["user_requirement"],
+        llm_service=state.get("llm_service"),
+        config=config,
     )
 
     print("</input_writer>")
@@ -121,7 +99,6 @@ def _initial_write_mode(state):
 
     return {
         "dir_structure": dir_structure,
-        "commands": [],
+        "commands": allrun_out["commands"],
         "foamfiles": foamfiles,
     }
-

--- a/src/nodes/local_runner_node.py
+++ b/src/nodes/local_runner_node.py
@@ -1,19 +1,39 @@
-# runner_node.py
-from typing import List
-import os
-from pydantic import BaseModel, Field
-import re
+"""Common execution node with policy-specific execution adapters."""
 
+from typing import Any
+
+from nodes.imported_case_node import run_imported_case_attempt
 from services.run_local import run_allrun_and_collect_errors
 from logger import log_review
 
 
-def local_runner_node(state):
+def local_runner_node(state: dict[str, Any]) -> dict[str, Any]:
     """
-    Runner node: Execute an Allrun script, and check for errors.
-    On error, update state.error_command and state.error_content.
+    Execute a prepared case locally and return normalized error records.
+
+    Both input modes meet here only after their preparation stages:
+    generated cases execute Foam-Agent's ``Allrun``; imported cases execute a
+    data-only, validated command plan in their disposable work copy.  Keeping
+    the distinction as a policy prevents an imported user ``Allrun`` from
+    becoming executable merely because it reaches the shared graph node.
     """
-    config = state["config"]
+    execution_policy = state.get("execution_policy", "generated_allrun")
+    if execution_policy == "controlled_import":
+        return run_imported_case_attempt(state)
+    if execution_policy != "generated_allrun":
+        return {
+            "error_logs": [
+                {
+                    "file": "workflow",
+                    "error_content": (
+                        "Unsupported execution policy: "
+                        f"{execution_policy!r}. Refusing to execute the case."
+                    ),
+                }
+            ],
+            "termination_reason": "unsupported_execution_policy",
+        }
+
     case_dir = state["case_dir"]
     max_time_limit = state["config"].max_time_limit
 

--- a/src/nodes/meshing_node.py
+++ b/src/nodes/meshing_node.py
@@ -1,18 +1,5 @@
 from services.mesh import copy_custom_mesh, prepare_standard_mesh, handle_gmsh_mesh as service_handle_gmsh_mesh
 
-def handle_standard_mesh(state, case_dir):
-    """Handle standard OpenFOAM mesh generation."""
-    print("<meshing type=\"standard\">")
-    print("Using standard OpenFOAM mesh generation (blockMesh, snappyHexMesh, etc.)")
-    print("</meshing>")
-    return {
-        "mesh_info": None,
-        "mesh_commands": [],
-        "mesh_file_destination": None,
-        "custom_mesh_used": False,
-        "error_logs": []
-    }
-
 def meshing_node(state):
     """
     Meshing node: Handle different mesh scenarios based on user requirements.
@@ -27,9 +14,9 @@ def meshing_node(state):
       - mesh_commands: Commands needed for mesh processing
       - mesh_file_destination: Where the mesh file should be placed
     """
-    config = state["config"]
     user_requirement = state["user_requirement"]
     case_dir = state["case_dir"]
+    llm_service = state.get("llm_service")
     
     # Get mesh type from state (determined by router)
     mesh_type = state.get("mesh_type", "standard_mesh")
@@ -38,12 +25,27 @@ def meshing_node(state):
     print("<meshing>")
     if mesh_type == "custom_mesh":
         print("<mesh_routing>Custom mesh requested.</mesh_routing>")
-        result = copy_custom_mesh(state.get("custom_mesh_path"), user_requirement, case_dir)  # service
+        result = copy_custom_mesh(
+            state.get("custom_mesh_path"),
+            user_requirement,
+            case_dir,
+            llm_service=llm_service,
+        )
     elif mesh_type == "gmsh_mesh":
         print("<mesh_routing>GMSH mesh requested.</mesh_routing>")
-        result = service_handle_gmsh_mesh(state, case_dir)  # service
+        result = service_handle_gmsh_mesh(
+            user_requirement,
+            case_dir,
+            state["config"].max_loop,
+            llm_service=llm_service,
+        )
     else:
         print("<mesh_routing>Standard mesh generation.</mesh_routing>")
         result = prepare_standard_mesh(user_requirement, case_dir)  # service
     print("</meshing>")
+    if result.get("error_logs"):
+        # There is no valid case to write or run after mesh preparation fails.
+        # Persist a terminal reason so the graph can stop before Input Writer
+        # obscures the original mesh error with unrelated dictionary failures.
+        result["termination_reason"] = "mesh_generation_failed"
     return result

--- a/src/nodes/planner_node.py
+++ b/src/nodes/planner_node.py
@@ -1,29 +1,14 @@
-# planner_node.py
-import os
-import re
-from typing import Dict, Any, List, Tuple
-from pathlib import Path
-from pydantic import BaseModel, Field
-import shutil
-from utils import save_file, retrieve_faiss, parse_directory_structure, LLMService
+"""Thin LangGraph adapter for planning and output-directory preparation."""
+
+from utils import save_file
 from services.plan import generate_simulation_plan
-from services import global_llm_service
+from services.output_safety import (
+    OutputDirectorySafetyError,
+    prepare_output_directory,
+    validate_output_preparation,
+)
 from router_func import llm_requires_custom_mesh, llm_requires_hpc, llm_requires_visualization
 from logger import setup_logging
-
-class CaseSummaryPydantic(BaseModel):
-    case_name: str = Field(description="name of the case")
-    case_domain: str = Field(description="domain of the case, case domain must be one of [basic,combustion,compressible,discreteMethods,DNS,electromagnetics,financial,heatTransfer,incompressible,lagrangian,mesh,multiphase,resources,stressAnalysis].")
-    case_category: str = Field(description="category of the case")
-    case_solver: str = Field(description="solver of the case")
-
-
-class SubtaskPydantic(BaseModel):
-    file_name: str = Field(description="Name of the OpenFOAM input file")
-    folder_name: str = Field(description="Name of the folder where the foamfile should be stored")
-
-class OpenFOAMPlanPydantic(BaseModel):
-    subtasks: List[SubtaskPydantic] = Field(description="List of subtasks, each with its corresponding file and folder names")
 
 
 def planner_node(state):
@@ -36,12 +21,29 @@ def planner_node(state):
     config = state["config"]
     user_requirement = state["user_requirement"]
 
+    # Fail before planning/RAG/LLM calls when the CLI points at a protected
+    # non-empty output directory. The later check remains necessary for the
+    # default case-name-derived output path.
+    requested_case_dir = getattr(config, "case_dir", "")
+    if requested_case_dir:
+        try:
+            validate_output_preparation(
+                requested_case_dir,
+                overwrite=getattr(config, "overwrite_case_dir", False),
+            )
+        except OutputDirectorySafetyError as exc:
+            raise ValueError(str(exc)) from exc
+
     # Generate simulation plan using the core planning logic
     plan_data = generate_simulation_plan(
         user_requirement=user_requirement,
         case_stats=state["case_stats"],
         case_dir=getattr(config, "case_dir", ""),
         searchdocs=getattr(config, "searchdocs", 2),
+        run_directory=getattr(config, "run_directory", None),
+        run_times=getattr(config, "run_times", 1),
+        config=config,
+        llm_service=state.get("llm_service"),
     )
     
     # Extract plan data
@@ -57,11 +59,18 @@ def planner_node(state):
     subtasks = plan_data["subtasks"]
     similar_case_advice = plan_data.get("similar_case_advice")
     
-    # Handle case directory creation/cleanup
-    if os.path.exists(case_dir):
-        print(f"Warning: Case directory {case_dir} already exists. Overwriting.")
-        shutil.rmtree(case_dir)
-    os.makedirs(case_dir)
+    # Prepare the known Foam-Agent-owned case directory only after planning.
+    # The preflight above avoids expensive LLM/RAG work when an explicit target
+    # is already unsafe; this call also covers a planner-derived default path.
+    try:
+        case_dir = str(
+            prepare_output_directory(
+                case_dir,
+                overwrite=getattr(config, "overwrite_case_dir", False),
+            )
+        )
+    except OutputDirectorySafetyError as exc:
+        raise ValueError(str(exc)) from exc
 
     # Initialize logging now that case_dir exists
     setup_logging(case_dir)

--- a/src/nodes/reviewer_node.py
+++ b/src/nodes/reviewer_node.py
@@ -1,15 +1,28 @@
-# reviewer_node.py
-from pydantic import BaseModel, Field
-from typing import List
+"""Common repair-decision node with policy-specific repair adapters."""
+
+from typing import Any
+
+from nodes.imported_case_node import repair_imported_case
 from services.review import review_error_logs, generate_rewrite_plan
 from logger import log_review
 
 
-def reviewer_node(state):
+def reviewer_node(state: dict[str, Any]) -> dict[str, Any]:
     """
-    Reviewer node: Reviews the error logs and provides analysis and suggestions
-    for fixing the errors. This node only focuses on analysis, not file modification.
+    Select the allowed repair strategy for a failed prepared case.
+
+    Generated cases receive an LLM analysis plus a constrained rewrite plan.
+    Imported cases never reach that LLM path: they receive only deterministic
+    non-numeric repairs approved by the import policy.
     """
+    repair_policy = state.get("repair_policy", "llm_rewrite")
+    if repair_policy == "numeric_invariant_only":
+        return repair_imported_case(state)
+    if repair_policy != "llm_rewrite":
+        return {
+            "termination_reason": "unsupported_repair_policy",
+        }
+
     print("<reviewer>")
     if len(state["error_logs"]) == 0:
         print("No error to review.")
@@ -28,6 +41,7 @@ def reviewer_node(state):
         user_requirement=state.get('user_requirement', ''),
         similar_case_advice=state.get('similar_case_advice'),
         history_text=history_text,
+        llm_service=state.get("llm_service"),
     )
 
     log_review(review_content, "review_analysis")
@@ -37,15 +51,23 @@ def reviewer_node(state):
         error_logs=state.get('error_logs', []),
         review_analysis=review_content,
         user_requirement=state.get('user_requirement', ''),
+        llm_service=state.get("llm_service"),
     )
     log_review(str(rewrite_plan), "rewrite_plan")
 
     print("</reviewer>")
 
-    return {
+    next_loop_count = state.get("loop_count", 0) + 1
+    result = {
         "history_text": updated_history,
         "review_analysis": review_content,
         "rewrite_plan": rewrite_plan,
-        "loop_count": state.get("loop_count", 0) + 1,
+        "loop_count": next_loop_count,
         "input_writer_mode": "rewrite",
     }
+    # Conditional-edge router mutations are not persisted by LangGraph. Store
+    # the terminal reason in this node update so the CLI can return a non-zero
+    # exit status when the retry budget is exhausted.
+    if next_loop_count >= state["config"].max_loop:
+        result["termination_reason"] = "max_review_loop_reached"
+    return result

--- a/src/nodes/visualization_node.py
+++ b/src/nodes/visualization_node.py
@@ -1,229 +1,31 @@
 # visualization_node.py
-import os
-from services.visualization import (
-    ensure_foam_file,
-    generate_deterministic_pyvista_script,
-    generate_pyvista_script,
-    run_pyvista_script,
-    fix_pyvista_script,
-)
+"""Thin LangGraph adapter for visualization."""
 
-
-# Routing should decide whether to enter this node (see router_func.llm_requires_visualization).
-
-def _guess_primary_field(user_requirement: str) -> str:
-    """Very small heuristic; keep deterministic and conservative."""
-    if not user_requirement:
-        return "U"
-    text = user_requirement
-    # Prefer explicit mentions
-    if " p " in f" {text} " or "pressure" in text.lower():
-        return "p"
-    if "temperature" in text.lower():
-        return "T"
-    if "u" in text.lower() or "velocity" in text.lower():
-        return "U"
-    return "U"
+from services.visualization import visualize_case
 
 def visualization_node(state):
-    """Visualization node: create a minimal PyVista screenshot for an OpenFOAM case.
-
-    Design goals:
-      - Only run if the user asked for visualization
-      - Deterministic output path + deterministic artifact detection
-      - Prefer a fixed, headless-safe renderer; fall back to LLM self-correct if needed
-    """
-    user_requirement = state.get("user_requirement", "")
-    case_dir = state.get("case_dir")
-
+    """Delegate visualization work and merge its result into graph state."""
     print("<visualization>")
-
-    # Note: routing logic should decide whether we reach this node.
-
-    if not case_dir:
-        print("</visualization>")
-        return {
-            **state,
-            "plot_configs": [],
-            "plot_outputs": [],
-            "visualization_summary": {"error": "Missing case_dir"},
-            "pyvista_visualization": {"success": False, "error": "Missing case_dir"},
-        }
-
-    case_dir = os.path.abspath(case_dir)
-    if not os.path.exists(case_dir):
-        print(f"Case directory does not exist: {case_dir}")
-        print("</visualization>")
-        return {
-            **state,
-            "plot_configs": [],
-            "plot_outputs": [],
-            "visualization_summary": {"error": f"Case directory does not exist: {case_dir}"},
-            "pyvista_visualization": {"success": False, "error": f"Case directory does not exist: {case_dir}"},
-        }
-
-    foam_file = ensure_foam_file(case_dir)
-
-    max_loop = getattr(state.get("config"), "max_loop", 2)
-    timeout_s = 180
-
-    # Deterministic artifact path (relative to case_dir)
-    output_png_rel = "visualization.png"
-
-    field_name = _guess_primary_field(user_requirement)
-
-    error_logs = []
-
-    # Attempt 1: deterministic template (preferred)
-    deterministic_script = generate_deterministic_pyvista_script(
-        foam_file=foam_file,
-        output_png=output_png_rel,
-        field_preference=field_name,
+    result = visualize_case(
+        state.get("case_dir"),
+        state.get("user_requirement", ""),
+        llm_service=state.get("llm_service"),
+        allow_llm_fallback=state.get("execution_policy") != "controlled_import",
     )
-    success, output_image, errs = run_pyvista_script(
-        case_dir,
-        deterministic_script,
-        filename="visualization.py",
-        expected_png=output_png_rel,
-        timeout_s=timeout_s,
-    )
-    if success and output_image:
-        plot_configs = [
-            {
-                "plot_type": "pyvista",
-                "field_name": field_name,
-                "time_step": "latest",
-                "output_format": "png",
-                "output_path": output_image,
-            }
-        ]
-        print("</visualization>")
-        return {
-            **state,
-            "plot_configs": plot_configs,
-            "plot_outputs": [output_image],
-            "visualization_summary": {
-                "total_plots_generated": 1,
-                "plot_types": ["pyvista"],
-                "fields_visualized": [field_name],
-                "output_directory": case_dir,
-                "pyvista_success": True,
-                "used": "deterministic_template",
-            },
-            "pyvista_visualization": {
-                "success": True,
-                "output_image": output_image,
-                "script": deterministic_script,
-                "used": "deterministic_template",
-            },
-        }
-
-    error_logs.extend(errs)
-
-    # Fallback: LLM generate + self-correct loop (kept, but artifact path is deterministic)
-    current_loop = 0
-    while current_loop < max_loop:
-        current_loop += 1
-        print(f"LLM visualization attempt {current_loop} of {max_loop}")
-
-        viz_script = generate_pyvista_script(case_dir, foam_file, user_requirement, error_logs[-2:])
-        success, output_image, errs = run_pyvista_script(
-            case_dir,
-            viz_script,
-            filename="visualization_llm.py",
-            expected_png=output_png_rel,
-            timeout_s=timeout_s,
-        )
-
-        if success and output_image:
-            plot_configs = [
-                {
-                    "plot_type": "pyvista",
-                    "field_name": field_name,
-                    "time_step": "latest",
-                    "output_format": "png",
-                    "output_path": output_image,
-                }
-            ]
-            print("</visualization>")
-            return {
-                **state,
-                "plot_configs": plot_configs,
-                "plot_outputs": [output_image],
-                "visualization_summary": {
-                    "total_plots_generated": 1,
-                    "plot_types": ["pyvista"],
-                    "fields_visualized": [field_name],
-                    "output_directory": case_dir,
-                    "pyvista_success": True,
-                    "used": "llm_script",
-                },
-                "pyvista_visualization": {
-                    "success": True,
-                    "output_image": output_image,
-                    "script": viz_script,
-                    "used": "llm_script",
-                },
-            }
-
-        error_logs.extend(errs)
-
-        if current_loop < max_loop:
-            fixed_script = fix_pyvista_script(foam_file, viz_script, error_logs[-2:])
-            success, output_image, errs = run_pyvista_script(
-                case_dir,
-                fixed_script,
-                filename="visualization_fixed.py",
-                expected_png=output_png_rel,
-                timeout_s=timeout_s,
-            )
-            if success and output_image:
-                plot_configs = [
-                    {
-                        "plot_type": "pyvista",
-                        "field_name": field_name,
-                        "time_step": "latest",
-                        "output_format": "png",
-                        "output_path": output_image,
-                    }
-                ]
-                print("</visualization>")
-                return {
-                    **state,
-                    "plot_configs": plot_configs,
-                    "plot_outputs": [output_image],
-                    "visualization_summary": {
-                        "total_plots_generated": 1,
-                        "plot_types": ["pyvista"],
-                        "fields_visualized": [field_name],
-                        "output_directory": case_dir,
-                        "pyvista_success": True,
-                        "used": "llm_fixed_script",
-                    },
-                    "pyvista_visualization": {
-                        "success": True,
-                        "output_image": output_image,
-                        "script": fixed_script,
-                        "used": "llm_fixed_script",
-                    },
-                }
-            error_logs.extend(errs)
-
-    error_message = f"Visualization failed after {max_loop} LLM attempts"
-    print(f"<visualization_error>{error_message}</visualization_error>")
+    if not result["pyvista_visualization"]["success"]:
+        print(f"<visualization_error>{result['pyvista_visualization']['error']}</visualization_error>")
     print("</visualization>")
-    return {
-        **state,
-        "plot_configs": [],
-        "plot_outputs": [],
-        "visualization_summary": {
-            "total_plots_generated": 0,
-            "plot_types": [],
-            "fields_visualized": [],
-            "output_directory": case_dir,
-            "pyvista_success": False,
-            "error": error_message,
-            "error_logs": error_logs,
-        },
-        "pyvista_visualization": {"success": False, "error": error_message, "error_logs": error_logs},
-    }
+    if (
+        state.get("execution_policy") == "controlled_import"
+        and not result["pyvista_visualization"]["success"]
+    ):
+        # Imported cases promise a deterministic, non-LLM visualization path.
+        # Treat an unavailable renderer as a failed requested operation instead
+        # of reporting the simulation as fully successful.
+        return {
+            **state,
+            **result,
+            "case_import_status": "visualization_failed",
+            "termination_reason": "imported_case_visualization_failed",
+        }
+    return {**state, **result}

--- a/src/router_func.py
+++ b/src/router_func.py
@@ -1,8 +1,15 @@
-from typing import TypedDict, List, Optional
-from config import Config
-from utils import LLMService, GraphState
-from langgraph.graph import StateGraph, START, END
-from langgraph.types import Command
+from langgraph.graph import END
+
+from utils import GraphState
+
+
+def route_workflow_entry(state: GraphState):
+    """Choose the prompt-generation or protected existing-case branch."""
+    if state.get("workflow_mode") == "imported_case":
+        print("<router>Existing case requested. Routing to case_import node.</router>")
+        return "case_import"
+    print("<router>Prompt workflow requested. Routing to planner node.</router>")
+    return "planner"
 
 
 def llm_requires_custom_mesh(state: GraphState) -> int:
@@ -121,6 +128,14 @@ def route_after_planner(state: GraphState):
         return "input_writer"
 
 
+def route_after_meshing(state: GraphState):
+    """Continue only when a requested mesh was prepared successfully."""
+    if state.get("error_logs"):
+        print("<router>Mesh preparation failed. Ending workflow.</router>")
+        return END
+    return "input_writer"
+
+
 def route_after_input_writer(state: GraphState):
     """
     Route after input_writer node based on whether user wants to run on HPC.
@@ -151,12 +166,27 @@ def route_after_runner(state: GraphState):
         return "visualization"
     return END
 
+def route_after_case_import(state: GraphState):
+    """Merge a validated imported case into the common local-runner path."""
+    return "local_runner" if state.get("case_import_status") == "ready" else END
+
+
 def route_after_reviewer(state: GraphState):
+    """Retry through the common runner, subject to the source repair policy."""
+    repair_policy = state.get("repair_policy", "llm_rewrite")
+    if repair_policy == "numeric_invariant_only":
+        return (
+            "local_runner"
+            if state.get("case_import_status") == "ready"
+            else END
+        )
+    if repair_policy != "llm_rewrite":
+        return END
+
     loop_count = state.get("loop_count", 0)
     max_loop = state["config"].max_loop
     if loop_count >= max_loop:
         print(f"<router>Maximum loop count ({max_loop}) reached. Ending workflow.</router>")
-        state["termination_reason"] = "max_review_loop_reached"
         requires_visualization = state.get("requires_visualization")
         if requires_visualization is None:
             requires_visualization = llm_requires_visualization(state)

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -2,5 +2,27 @@
 from utils import LLMService
 from config import Config
 
-# Global LLM service instance for services
-global_llm_service = LLMService(Config())
+
+class _LazyLLMService:
+    """Create the configured LLM only when a workflow actually invokes it.
+
+    Service modules are also imported by deterministic preflight checks and
+    unit tests.  Constructing an OAuth-backed client at import time made those
+    local operations depend on credentials that they never use.
+    """
+
+    def __init__(self) -> None:
+        self._instance = None
+
+    def _get_instance(self) -> LLMService:
+        if self._instance is None:
+            self._instance = LLMService(Config())
+        return self._instance
+
+    def __getattr__(self, name: str):
+        return getattr(self._get_instance(), name)
+
+
+# Legacy callers retain the ``global_llm_service.invoke(...)`` interface,
+# while import-only code remains free of network and credential side effects.
+global_llm_service = _LazyLLMService()

--- a/src/services/allrun_commands.py
+++ b/src/services/allrun_commands.py
@@ -1,0 +1,158 @@
+"""Small, shared helpers for inspecting OpenFOAM ``Allrun`` scripts.
+
+The project has two deliberately different execution policies:
+
+* generated cases may contain normal OpenFOAM shell scripts;
+* imported cases accept only a tightly restricted command subset.
+
+Both policies still need to answer the same non-security question: which
+OpenFOAM command does a line invoke?  Keeping that recognition in one place
+avoids the generated-run, imported-run, and writer paths disagreeing about
+the ordering of mesh generation, ``checkMesh``, and the solver.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import Iterable
+
+
+_NON_COMMAND_PREFIXES = frozenset(
+    {
+        ".",
+        "cd",
+        "do",
+        "done",
+        "echo",
+        "else",
+        "fi",
+        "for",
+        "if",
+        "source",
+        "then",
+    }
+)
+_RUN_WRAPPERS = frozenset({"runApplication", "runParallel"})
+_APPLICATION_VARIABLES = frozenset(
+    {"$(getApplication)", "$application", "${application}", "getApplication"}
+)
+
+
+def strip_shell_comment(line: str) -> str:
+    """Remove a shell comment for the restricted Allrun grammar we inspect."""
+    return line.split("#", 1)[0].strip()
+
+
+def normalise_shell_lines(script: str) -> list[str]:
+    """Join trailing-backslash continuations without executing shell syntax."""
+    lines: list[str] = []
+    pending = ""
+    for raw_line in script.replace("\r\n", "\n").replace("\r", "\n").splitlines():
+        line = raw_line.rstrip()
+        if line.endswith("\\"):
+            pending += line[:-1] + " "
+            continue
+        lines.append(pending + line)
+        pending = ""
+    if pending:
+        raise ValueError("Allrun ends with an unfinished line continuation.")
+    return lines
+
+
+def shell_tokens(line: str) -> list[str]:
+    """Return shell words for one line, or an empty list when it is malformed.
+
+    This is intentionally inspection-only.  It neither expands variables nor
+    accepts a line as safe to execute; import mode applies its stricter policy
+    separately.
+    """
+    code = strip_shell_comment(line)
+    if not code:
+        return []
+    try:
+        return shlex.split(code, posix=True)
+    except ValueError:
+        return []
+
+
+def invoked_command_from_tokens(tokens: Iterable[str]) -> str:
+    """Return the OpenFOAM command represented by simple Allrun tokens."""
+    words = list(tokens)
+    if not words:
+        return ""
+    first = words[0]
+    if first in _RUN_WRAPPERS:
+        return words[1] if len(words) > 1 else ""
+    if "=" in first or first in _NON_COMMAND_PREFIXES:
+        return ""
+    return first
+
+
+def invoked_command(line: str) -> str:
+    """Return the command invoked by a simple Allrun line, if any."""
+    return invoked_command_from_tokens(shell_tokens(line))
+
+
+def line_invokes_command(line: str, command: str) -> bool:
+    tokens = shell_tokens(line)
+    if tokens and tokens[0] in {"mpirun", "mpiexec"}:
+        return command in tokens[1:]
+    return invoked_command_from_tokens(tokens) == command
+
+
+def line_invokes_solver(line: str, solver: str) -> bool:
+    """Recognise literal or standard ``getApplication`` solver invocations."""
+    tokens = shell_tokens(line)
+    if not tokens:
+        return False
+    command = invoked_command_from_tokens(tokens)
+    if solver and command == solver:
+        return True
+    return (
+        tokens[0] in _RUN_WRAPPERS
+        and len(tokens) > 1
+        and tokens[1] in _APPLICATION_VARIABLES
+    )
+
+
+def command_positions(script: str, command: str) -> list[int]:
+    """Return source offsets where a command is actually invoked."""
+    positions: list[int] = []
+    offset = 0
+    for raw_line in script.splitlines(keepends=True):
+        if line_invokes_command(raw_line, command):
+            positions.append(offset + raw_line.find(command))
+        offset += len(raw_line)
+    return positions
+
+
+def application_positions(script: str, application: str | None) -> list[int]:
+    """Return literal and standard variable-based solver invocation offsets."""
+    if not application:
+        return []
+    positions: list[int] = []
+    offset = 0
+    for raw_line in script.splitlines(keepends=True):
+        if line_invokes_solver(raw_line, application):
+            command = invoked_command(raw_line)
+            positions.append(offset + raw_line.find(command or "run"))
+        offset += len(raw_line)
+    return sorted(set(positions))
+
+
+def script_without_comments(script: str) -> str:
+    """Remove comments while preserving one line per source line."""
+    return "\n".join(strip_shell_comment(line) for line in script.splitlines())
+
+
+def is_standard_application_variable(token: str) -> bool:
+    return token in _APPLICATION_VARIABLES
+
+
+def allrun_uses_runfunctions(lines: Iterable[str]) -> bool:
+    return any("RunFunctions" in strip_shell_comment(line) for line in lines)
+
+
+def is_run_wrapper(line: str) -> bool:
+    tokens = shell_tokens(line)
+    return bool(tokens and tokens[0] in _RUN_WRAPPERS)

--- a/src/services/case_import.py
+++ b/src/services/case_import.py
@@ -1,0 +1,457 @@
+"""Public orchestration API for safely importing existing OpenFOAM cases.
+
+The detailed responsibilities live in focused modules:
+
+* :mod:`case_import_source` validates and materialises an input;
+* :mod:`case_import_allrun` converts an allowed Allrun into a safe plan;
+* :mod:`case_import_repairs` owns the strict non-numeric repair policy.
+
+Keeping this module as the orchestration boundary makes the CLI-facing API
+small without hiding the safety rules behind a single 1300-line service.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import stat
+from typing import Any
+
+from logger import close_logging, setup_logging
+from utils import check_foam_errors, run_command
+from .case_import_allrun import render_controlled_allrun
+from .case_import_models import (
+    CaseImportError,
+    CaseManifest,
+    ExecutionStep,
+    ImportRunResult,
+)
+from .case_import_repairs import (
+    apply_safe_repairs,
+    numeric_signature,
+)
+from .case_import_source import import_case, iter_regular_files
+from .run_local import (
+    validate_openfoam_case_postflight,
+    validate_openfoam_case_preflight,
+)
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _clear_attempt_artifacts(case_dir: Path) -> None:
+    """Clear only import-attempt logs, never source dictionaries or time folders."""
+    for path in case_dir.iterdir():
+        if path.is_file() and (
+            path.name.startswith("log.")
+            or path.name in {"Allrun.import.out", "Allrun.import.err"}
+        ):
+            path.unlink(missing_ok=True)
+
+
+def _capture_safe_work_overrides(
+    original_dir: Path,
+    work_dir: Path,
+) -> dict[str, bytes]:
+    """Keep only numeric-invariant input edits for a clean retry."""
+    overrides: dict[str, bytes] = {}
+    for work_path in iter_regular_files(work_dir):
+        if ".foamagent" in work_path.parts:
+            continue
+        relative = work_path.relative_to(work_dir)
+        original_path = original_dir / relative
+        if not original_path.is_file():
+            continue
+        try:
+            old_bytes = original_path.read_bytes()
+            new_bytes = work_path.read_bytes()
+        except OSError as exc:
+            raise RuntimeError(f"Unable to capture safe repair {relative}: {exc}") from exc
+        if old_bytes == new_bytes:
+            continue
+        old_text = old_bytes.decode("utf-8", errors="replace")
+        new_text = new_bytes.decode("utf-8", errors="replace")
+        if numeric_signature(old_text) != numeric_signature(new_text):
+            raise RuntimeError(f"Repair for {relative} changed numeric inputs and cannot be replayed.")
+        overrides[relative.as_posix()] = new_bytes
+    return overrides
+
+
+def _make_work_tree_writable(work_dir: Path) -> None:
+    for path in (work_dir, *work_dir.rglob("*")):
+        if path.is_symlink():
+            continue
+        try:
+            path.chmod(path.stat().st_mode | stat.S_IWUSR)
+        except OSError as exc:
+            raise RuntimeError(f"Unable to prepare mutable work copy {path}: {exc}") from exc
+
+
+def _restore_clean_work_copy(
+    original_dir: Path,
+    work_dir: Path,
+    overrides: dict[str, bytes],
+) -> None:
+    """Restore immutable input and replay only prior approved repairs."""
+    shutil.rmtree(work_dir, ignore_errors=True)
+    shutil.copytree(original_dir, work_dir)
+    _make_work_tree_writable(work_dir)
+    for relative, content in overrides.items():
+        destination = work_dir / Path(relative)
+        try:
+            destination.relative_to(work_dir)
+        except ValueError as exc:
+            raise RuntimeError(f"Unsafe stored repair path: {relative}") from exc
+        if not destination.is_file():
+            raise RuntimeError(f"Stored repair target disappeared: {relative}")
+        destination.write_bytes(content)
+
+
+def execute_imported_case(
+    work_dir: str | Path,
+    manifest: CaseManifest,
+    *,
+    timeout: int,
+) -> list[Any]:
+    """Execute the generated controlled script in an imported case work copy."""
+    case_dir = Path(work_dir)
+    controlled_dir = case_dir / ".foamagent"
+    controlled_dir.mkdir(exist_ok=True)
+    controlled_script = controlled_dir / "Allrun.controlled"
+    script_content = render_controlled_allrun(manifest.execution_plan)
+    controlled_script.write_text(script_content, encoding="utf-8")
+
+    preflight = validate_openfoam_case_preflight(str(case_dir), script_content)
+    if preflight:
+        return preflight
+
+    _clear_attempt_artifacts(case_dir)
+    out_file = case_dir / "Allrun.import.out"
+    err_file = case_dir / "Allrun.import.err"
+    try:
+        command_result = run_command(
+            str(controlled_script),
+            str(out_file),
+            str(err_file),
+            str(case_dir),
+            timeout,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        return [{"file": "Allrun", "error_content": str(exc)}]
+
+    errors: list[Any] = []
+    if command_result.get("timed_out"):
+        errors.append(
+            {
+                "file": "Allrun",
+                "error_content": f"Controlled execution exceeded the {timeout} second timeout.",
+            }
+        )
+    elif command_result.get("returncode") not in (None, 0):
+        errors.append(
+            {
+                "file": "Allrun",
+                "error_content": "Controlled execution exited with non-zero return code "
+                f"{command_result.get('returncode')}.",
+            }
+        )
+    errors.extend(check_foam_errors(str(case_dir)))
+    errors.extend(validate_openfoam_case_postflight(str(case_dir), script_content))
+
+    deduplicated: list[Any] = []
+    seen: set[str] = set()
+    for error in errors:
+        marker = json.dumps(error, sort_keys=True, default=str)
+        if marker not in seen:
+            seen.add(marker)
+            deduplicated.append(error)
+    return deduplicated
+
+
+def write_import_attempt_report(report_dir: str | Path, attempts: list[dict[str, Any]]) -> None:
+    """Persist the complete current history of import attempts."""
+    report_dir = Path(report_dir)
+    _write_json(report_dir / "attempts.json", attempts)
+
+
+def prepare_imported_work_tree(work_dir: str | Path) -> None:
+    """Make the disposable work copy writable before a controlled run."""
+    _make_work_tree_writable(Path(work_dir))
+
+
+def restore_imported_work_tree(
+    original_dir: str | Path,
+    work_dir: str | Path,
+    overrides: dict[str, bytes],
+) -> None:
+    """Recreate ``work/`` from ``original/`` and replay approved safe repairs."""
+    _restore_clean_work_copy(Path(original_dir), Path(work_dir), overrides)
+
+
+def capture_safe_import_overrides(
+    original_dir: str | Path,
+    work_dir: str | Path,
+) -> dict[str, bytes]:
+    """Return only numeric-invariant repairs that may be replayed on retry."""
+    return _capture_safe_work_overrides(Path(original_dir), Path(work_dir))
+
+
+def _error_fingerprint(errors: list[Any]) -> str:
+    """Produce a stable marker so an unchanged failed retry stops promptly."""
+    return hashlib.sha256(
+        json.dumps(errors, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+
+def _blocked_import_attempt(
+    attempts: list[dict[str, Any]],
+    report_dir: str | Path,
+    reason: str,
+    error_fingerprints: list[str],
+) -> dict[str, Any]:
+    """Persist a terminal import attempt in the format shared by both runners."""
+    if attempts:
+        attempts[-1] = {**attempts[-1], "terminal_reason": reason}
+    write_import_attempt_report(report_dir, attempts)
+    return {
+        "attempts": attempts,
+        "status": "blocked",
+        "termination_reason": reason,
+        "error_fingerprints": error_fingerprints,
+    }
+
+
+def execute_imported_case_attempt(
+    manifest: CaseManifest,
+    *,
+    original_dir: str | Path,
+    work_dir: str | Path,
+    report_dir: str | Path,
+    attempts: list[dict[str, Any]],
+    overrides: dict[str, bytes],
+    timeout: int,
+    executor: Any = None,
+) -> dict[str, Any]:
+    """Run and record one controlled imported-case attempt.
+
+    This is the one shared transition used by the direct public API and the
+    LangGraph runner adapter.  The optional executor keeps the adapter easy to
+    test while production callers use :func:`execute_imported_case`.
+    """
+    attempts = list(attempts)
+    try:
+        if attempts:
+            restore_imported_work_tree(original_dir, work_dir, overrides)
+        run_case = executor if executor is not None else execute_imported_case
+        errors = run_case(work_dir, manifest, timeout=timeout)
+    except Exception as exc:  # Keep every runner failure in the audited history.
+        errors = [{"file": "Allrun", "error_content": str(exc)}]
+
+    record = {"attempt": len(attempts) + 1, "errors": errors, "repairs": []}
+    attempts.append(record)
+    write_import_attempt_report(report_dir, attempts)
+    return {
+        "attempts": attempts,
+        "status": "success" if not errors else "running",
+        "errors": errors,
+    }
+
+
+def repair_imported_case_attempt(
+    *,
+    original_dir: str | Path,
+    work_dir: str | Path,
+    report_dir: str | Path,
+    attempts: list[dict[str, Any]],
+    errors: list[Any],
+    error_fingerprints: list[str],
+    loop_count: int,
+    max_repairs: int,
+) -> dict[str, Any]:
+    """Apply at most one approved repair and return the next import state.
+
+    Both execution entry points now share fingerprint handling, retry limits,
+    report updates, and numeric-invariant override capture through this
+    transition rather than maintaining parallel retry implementations.
+    """
+    attempts = list(attempts)
+    known_fingerprints = list(error_fingerprints)
+    if not errors:
+        return {
+            "attempts": attempts,
+            "status": "success",
+            "error_fingerprints": known_fingerprints,
+        }
+
+    fingerprint = _error_fingerprint(errors)
+    if fingerprint in known_fingerprints:
+        return _blocked_import_attempt(
+            attempts,
+            report_dir,
+            "repeated_error_fingerprint",
+            known_fingerprints,
+        )
+
+    known_fingerprints.append(fingerprint)
+    if loop_count >= max_repairs:
+        return _blocked_import_attempt(
+            attempts,
+            report_dir,
+            "maximum_safe_repair_attempts_reached",
+            known_fingerprints,
+        )
+
+    repairs = apply_safe_repairs(work_dir, errors)
+    if attempts:
+        attempts[-1] = {**attempts[-1], "repairs": repairs}
+    write_import_attempt_report(report_dir, attempts)
+    if not any(repair.get("status") == "applied" for repair in repairs):
+        result = _blocked_import_attempt(
+            attempts,
+            report_dir,
+            "no_safe_non_numeric_repair_available",
+            known_fingerprints,
+        )
+        result["repairs"] = repairs
+        return result
+
+    return {
+        "attempts": attempts,
+        "overrides": capture_safe_import_overrides(original_dir, work_dir),
+        "error_fingerprints": known_fingerprints,
+        "loop_count": loop_count + 1,
+        "repairs": repairs,
+        "status": "ready",
+    }
+
+
+def _run_imported_manifest(
+    manifest: CaseManifest,
+    *,
+    timeout: int,
+    max_repairs: int,
+) -> ImportRunResult:
+    """Run a materialised case until it succeeds or no safe repair remains."""
+    output_root = Path(manifest.output_root)
+    original_dir = output_root / "original"
+    work_dir = output_root / "work"
+    report_dir = output_root / "report"
+    print("<case_import>")
+    print(f"<platform>{manifest.platform}</platform>")
+    print(f"<application>{manifest.application}</application>")
+    print(f"<allrun_provided>{manifest.allrun_provided}</allrun_provided>")
+    print("</case_import>")
+
+    attempts: list[dict[str, Any]] = []
+    if not manifest.supported:
+        errors = [
+            {"file": "case_manifest", "error_content": issue}
+            for issue in manifest.blocking_issues
+        ]
+        write_import_attempt_report(report_dir, attempts)
+        return ImportRunResult(
+            "blocked", str(original_dir), str(work_dir), str(report_dir), manifest, attempts, errors
+        )
+
+    # ``copytree`` deliberately retains the source mode bits.  The immutable
+    # ``original`` copy is useful for auditability, but the first execution
+    # must have the same writable work tree as later repair attempts.  Without
+    # this, a read-only uploaded case fails before the controlled runner can
+    # create its private ``.foamagent`` directory.
+    prepare_imported_work_tree(work_dir)
+
+    prior_fingerprints: list[str] = []
+    approved_overrides: dict[str, bytes] = {}
+    errors: list[Any] = []
+    loop_count = 0
+    while True:
+        execution = execute_imported_case_attempt(
+            manifest,
+            original_dir=original_dir,
+            work_dir=work_dir,
+            report_dir=report_dir,
+            attempts=attempts,
+            overrides=approved_overrides,
+            timeout=timeout,
+        )
+        attempts = execution["attempts"]
+        errors = execution["errors"]
+        if execution["status"] == "success":
+            return ImportRunResult(
+                "success", str(original_dir), str(work_dir), str(report_dir), manifest, attempts, []
+            )
+
+        repair = repair_imported_case_attempt(
+            original_dir=original_dir,
+            work_dir=work_dir,
+            report_dir=report_dir,
+            attempts=attempts,
+            errors=errors,
+            error_fingerprints=prior_fingerprints,
+            loop_count=loop_count,
+            max_repairs=max_repairs,
+        )
+        attempts = repair["attempts"]
+        prior_fingerprints = repair["error_fingerprints"]
+        if repair["status"] != "ready":
+            return ImportRunResult(
+                "blocked",
+                str(original_dir),
+                str(work_dir),
+                str(report_dir),
+                manifest,
+                attempts,
+                errors,
+            )
+        approved_overrides = repair["overrides"]
+        loop_count = repair["loop_count"]
+
+
+def run_imported_case(
+    case_path: str | Path,
+    output_dir: str | Path,
+    *,
+    case_subdir: str | None = None,
+    overwrite: bool = False,
+    timeout: int = 3600,
+    max_repairs: int = 25,
+) -> ImportRunResult:
+    """Import, execute, and safely repair a Foundation v10 case."""
+    manifest = import_case(
+        case_path,
+        output_dir,
+        case_subdir=case_subdir,
+        overwrite=overwrite,
+    )
+    setup_logging(str(Path(manifest.output_root) / "report"))
+    try:
+        return _run_imported_manifest(
+            manifest,
+            timeout=timeout,
+            max_repairs=max_repairs,
+        )
+    finally:
+        close_logging()
+
+
+__all__ = [
+    "CaseImportError",
+    "CaseManifest",
+    "ExecutionStep",
+    "ImportRunResult",
+    "apply_safe_repairs",
+    "capture_safe_import_overrides",
+    "execute_imported_case",
+    "execute_imported_case_attempt",
+    "import_case",
+    "prepare_imported_work_tree",
+    "repair_imported_case_attempt",
+    "restore_imported_work_tree",
+    "run_imported_case",
+    "write_import_attempt_report",
+]

--- a/src/services/case_import_allrun.py
+++ b/src/services/case_import_allrun.py
@@ -1,0 +1,279 @@
+"""Restricted Allrun parser and renderer for imported OpenFOAM cases.
+
+Unlike generated cases, an imported ``Allrun`` is treated as untrusted input.
+This module turns a small Foundation-v10 subset into a data-only execution
+plan, then renders the controlled equivalent used by the runner.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+import re
+import shlex
+from typing import Iterable
+
+from .allrun_commands import (
+    is_standard_application_variable,
+    normalise_shell_lines,
+    strip_shell_comment,
+)
+from .case_import_models import CaseImportError, ExecutionStep
+from .openfoam_commands import MESH_MUTATING_COMMANDS
+
+
+_SHELL_META_RE = re.compile(r"[;&|`<>]")
+_SAFE_COMMAND_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+_SAFE_ARGUMENT_RE = re.compile(r"^[A-Za-z0-9_./:=+@%$,-]+$")
+_ALLOWED_UTILITY_COMMANDS = frozenset(
+    {
+        "blockMesh",
+        "checkMesh",
+        "createBaffles",
+        "createNonConformalCouples",
+        "decomposePar",
+        "fluentMeshToFoam",
+        "gmshToFoam",
+        "reconstructPar",
+        "setFields",
+        "snappyHexMesh",
+        "splitBaffles",
+        "splitMeshRegions",
+        "topoSet",
+    }
+)
+
+
+def _safe_tokens(command: str, args: Iterable[str]) -> None:
+    if not _SAFE_COMMAND_RE.fullmatch(command):
+        raise CaseImportError(f"Unsafe command in Allrun: {command!r}")
+    for arg in args:
+        if arg == "-case" or arg.startswith("-case="):
+            raise CaseImportError(
+                "Allrun -case arguments are not supported in safe case-import mode."
+            )
+        if not _SAFE_ARGUMENT_RE.fullmatch(arg) or _SHELL_META_RE.search(arg):
+            raise CaseImportError(f"Unsafe argument in Allrun: {arg!r}")
+        path_values = (arg.split("=", 1)[-1],) if "=" in arg else (arg,)
+        if any(value.startswith("/") for value in path_values):
+            raise CaseImportError(
+                f"Absolute paths are not allowed in imported Allrun: {arg!r}"
+            )
+        if any(".." in PurePosixPath(value).parts for value in path_values):
+            raise CaseImportError(
+                f"Parent-directory traversal is not allowed in Allrun: {arg!r}"
+            )
+        if "$" in arg:
+            raise CaseImportError(f"Unsupported shell expansion in Allrun: {arg!r}")
+
+
+def _resolve_application(token: str, application: str) -> str:
+    return application if is_standard_application_variable(token) else token
+
+
+def _shell_split(line: str) -> list[str]:
+    try:
+        return shlex.split(line, posix=True)
+    except ValueError as exc:
+        raise CaseImportError(f"Unable to parse Allrun line {line!r}: {exc}") from exc
+
+
+def _is_supported_setup_line(line: str) -> bool:
+    """Allow only Foundation v10's normal RunFunctions setup boilerplate."""
+    normalised = re.sub(r"\s+", " ", line).strip()
+    return normalised in {
+        ". $WM_PROJECT_DIR/bin/tools/RunFunctions",
+        '. "$WM_PROJECT_DIR/bin/tools/RunFunctions"',
+        "source $WM_PROJECT_DIR/bin/tools/RunFunctions",
+        'source "$WM_PROJECT_DIR/bin/tools/RunFunctions"',
+        "cd ${0%/*}",
+        'cd "${0%/*}"',
+        "cd ${0%/*} || exit 1",
+        'cd "${0%/*}" || exit 1',
+    }
+
+
+def _parse_execution_line(line: str, application: str) -> ExecutionStep:
+    """Parse one non-setup Allrun line into an allow-listed execution step."""
+    tokens = _shell_split(line)
+    if not tokens:
+        raise CaseImportError(f"Unable to parse Allrun command: {line!r}")
+    launcher = tokens.pop(0)
+    parallel = launcher == "runParallel"
+    if launcher in {"runApplication", "runParallel"}:
+        if not tokens:
+            raise CaseImportError(f"Allrun command lacks an application: {line!r}")
+        command = _resolve_application(tokens.pop(0), application)
+    else:
+        command = _resolve_application(launcher, application)
+    _safe_tokens(command, tokens)
+    if command != application and command not in _ALLOWED_UTILITY_COMMANDS:
+        raise CaseImportError(
+            f"Unsupported command in user Allrun: {command}. "
+            "Only Foundation v10 utilities and the controlDict application are allowed."
+        )
+    if parallel and command != application:
+        raise CaseImportError(
+            f"runParallel may only execute the controlDict application, not {command}."
+        )
+    return ExecutionStep(command, tuple(tokens), parallel)
+
+
+def _parse_allrun_line(line: str, application: str) -> ExecutionStep | None:
+    """Ignore known setup lines and parse an allowed OpenFOAM command."""
+    if not line or line.startswith("#!"):
+        return None
+    if line.startswith("application="):
+        if not re.fullmatch(r"application\s*=\s*\$?\(?getApplication\)?", line):
+            raise CaseImportError(f"Unsupported application assignment in Allrun: {line!r}")
+        return None
+    if line.startswith((".", "source ", "cd ")):
+        if not _is_supported_setup_line(line):
+            raise CaseImportError(
+                "Unsupported shell setup in Allrun. Only the standard "
+                "Foundation v10 RunFunctions source and case-directory cd are allowed."
+            )
+        return None
+    return _parse_execution_line(line, application)
+
+
+def parse_allrun(allrun_content: str, application: str) -> list[ExecutionStep]:
+    """Parse the supported, non-Turing-complete subset of an imported Allrun."""
+    try:
+        lines = normalise_shell_lines(allrun_content)
+    except ValueError as exc:
+        raise CaseImportError(str(exc)) from exc
+
+    steps = [
+        step
+        for raw_line in lines
+        if (step := _parse_allrun_line(strip_shell_comment(raw_line), application))
+        is not None
+    ]
+    if not steps:
+        raise CaseImportError("Allrun contains no supported OpenFOAM execution commands.")
+    return steps
+
+
+def synthesise_execution_plan(application: str, mesh_state: str) -> list[ExecutionStep]:
+    """Infer only the minimal execution plan for a self-contained case."""
+    if mesh_state == "existing-polyMesh":
+        steps = [ExecutionStep("checkMesh", origin="generated_missing_allrun")]
+        if application != "checkMesh":
+            steps.append(ExecutionStep(application, origin="generated_missing_allrun"))
+        return steps
+    if mesh_state == "blockMesh":
+        steps = [
+            ExecutionStep("blockMesh", origin="generated_missing_allrun"),
+            ExecutionStep("checkMesh", origin="generated_missing_allrun"),
+        ]
+        if application not in {"blockMesh", "checkMesh"}:
+            steps.append(ExecutionStep(application, origin="generated_missing_allrun"))
+        return steps
+    raise CaseImportError(
+        "Allrun is missing and the case has neither constant/polyMesh nor "
+        "system/blockMeshDict. A safe execution plan cannot be inferred."
+    )
+
+
+def ensure_mesh_check(
+    steps: list[ExecutionStep],
+    application: str,
+) -> list[ExecutionStep]:
+    """Ensure the selected application only sees a post-mesh ``checkMesh``."""
+    if not any(step.command == application for step in steps):
+        raise CaseImportError("Allrun never runs the application declared in system/controlDict.")
+
+    mesh_indexes = [
+        index for index, step in enumerate(steps) if step.command in MESH_MUTATING_COMMANDS
+    ]
+    if mesh_indexes:
+        last_mesh_index = max(mesh_indexes)
+        steps = [
+            step
+            for index, step in enumerate(steps)
+            if not (step.command == "checkMesh" and index <= last_mesh_index)
+        ]
+        mesh_indexes = [
+            index for index, step in enumerate(steps) if step.command in MESH_MUTATING_COMMANDS
+        ]
+
+    check_indexes = [
+        index for index, step in enumerate(steps) if step.command == "checkMesh"
+    ]
+    required_after = max(mesh_indexes) if mesh_indexes else -1
+    # ``checkMesh`` can itself be the controlDict application for a mesh-only
+    # tutorial.  Its existing invocation is already the required quality gate;
+    # inserting another one would run it twice.  If a mesh operation preceded
+    # it, the filtering above has removed stale pre-mesh checks and this branch
+    # inserts exactly one final check instead.
+    if application == "checkMesh":
+        if any(index > required_after for index in check_indexes):
+            return steps
+        repaired = list(steps)
+        repaired.insert(required_after + 1, ExecutionStep("checkMesh", origin="foamagent_mesh_gate"))
+        return repaired
+    if application in MESH_MUTATING_COMMANDS:
+        if any(index > required_after for index in check_indexes):
+            return steps
+        repaired = list(steps)
+        repaired.insert(required_after + 1, ExecutionStep("checkMesh", origin="foamagent_mesh_gate"))
+        return repaired
+
+    solver_index = next(index for index, step in enumerate(steps) if step.command == application)
+    if any(index > solver_index for index in mesh_indexes):
+        raise CaseImportError(
+            "Allrun modifies the mesh after the configured solver starts; "
+            "safe case-import mode requires mesh validation before the solver."
+        )
+    if any(required_after < index < solver_index for index in check_indexes):
+        return steps
+
+    repaired = list(steps)
+    repaired.insert(
+        required_after + 1 if mesh_indexes else solver_index,
+        ExecutionStep("checkMesh", origin="foamagent_mesh_gate"),
+    )
+    return repaired
+
+
+def render_controlled_allrun(steps: list[ExecutionStep]) -> str:
+    """Render a fail-closed equivalent of the validated execution plan."""
+    lines = [
+        "#!/bin/sh",
+        'cd "${0%/*}/.." || exit 1',
+        '. "$WM_PROJECT_DIR/bin/tools/RunFunctions"',
+        'if [ "${WM_PROJECT_VERSION:-}" != "10" ]; then',
+        '    echo "Foam-Agent case-import requires Foundation OpenFOAM v10 (WM_PROJECT_VERSION=10)." >&2',
+        "    exit 64",
+        "fi",
+        "foamagent_require_stock_command() {",
+        '    foamagent_command_path=$(command -v "$1") || {',
+        '        echo "Required OpenFOAM command is unavailable: $1" >&2',
+        "        return 64",
+        "    }",
+        '    case "$foamagent_command_path" in',
+        '        "$FOAM_APPBIN"/*) return 0 ;;',
+        '        *) echo "Custom or non-Foundation command is not allowed: $1 ($foamagent_command_path)" >&2; return 64 ;;',
+        "    esac",
+        "}",
+        "foamagent_require_mesh_ok() {",
+        '    foamagent_mesh_log="log.checkMesh"',
+        '    if [ ! -f "$foamagent_mesh_log" ]; then',
+        '        echo "checkMesh did not produce $foamagent_mesh_log" >&2',
+        "        return 65",
+        "    fi",
+        '    if grep -Eiq "Failed[[:space:]]+[1-9][0-9]*[[:space:]]+mesh checks?" "$foamagent_mesh_log" || ! grep -Eiq "Mesh[[:space:]]+OK" "$foamagent_mesh_log"; then',
+        '        echo "checkMesh did not establish a usable mesh; refusing to start a solver." >&2',
+        "        return 65",
+        "    fi",
+        "}",
+        "",
+    ]
+    for step in steps:
+        invocation = " ".join((step.command, *step.args)).strip()
+        lines.append(f"foamagent_require_stock_command {step.command} || exit $?")
+        runner = "runParallel" if step.parallel else "runApplication"
+        lines.append(f"{runner} {invocation} || exit $?")
+        if step.command == "checkMesh":
+            lines.append("foamagent_require_mesh_ok || exit $?")
+    return "\n".join(lines) + "\n"

--- a/src/services/case_import_models.py
+++ b/src/services/case_import_models.py
@@ -1,0 +1,83 @@
+"""Data contracts shared by the existing-case import workflow."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+
+class CaseImportError(ValueError):
+    """Raised when a case cannot safely enter import mode."""
+
+
+@dataclass(frozen=True)
+class ExecutionStep:
+    """One validated OpenFOAM command in the controlled execution plan."""
+
+    command: str
+    args: tuple[str, ...] = ()
+    parallel: bool = False
+    origin: str = "user_allrun"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "args": list(self.args),
+            "parallel": self.parallel,
+            "origin": self.origin,
+        }
+
+
+@dataclass
+class CaseManifest:
+    """Immutable description of a selected source case and its execution plan."""
+
+    source: str
+    case_root: str
+    output_root: str
+    platform: str
+    version: Optional[str]
+    application: str
+    allrun_provided: bool
+    mesh_state: str
+    execution_plan: list[ExecutionStep] = field(default_factory=list)
+    detected_libraries: list[str] = field(default_factory=list)
+    blocking_issues: list[str] = field(default_factory=list)
+    original_hashes: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def supported(self) -> bool:
+        return not self.blocking_issues and self.platform in {
+            "foundation-v10",
+            "foundation-v10-compatible",
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["execution_plan"] = [step.to_dict() for step in self.execution_plan]
+        result["supported"] = self.supported
+        return result
+
+
+@dataclass
+class ImportRunResult:
+    """Terminal result of importing and optionally executing a case."""
+
+    status: str
+    original_dir: str
+    work_dir: str
+    report_dir: str
+    manifest: CaseManifest
+    attempts: list[dict[str, Any]]
+    errors: list[Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "original_dir": self.original_dir,
+            "work_dir": self.work_dir,
+            "report_dir": self.report_dir,
+            "manifest": self.manifest.to_dict(),
+            "attempts": self.attempts,
+            "errors": self.errors,
+        }

--- a/src/services/case_import_repairs.py
+++ b/src/services/case_import_repairs.py
@@ -1,0 +1,171 @@
+"""Narrow, numeric-invariant repairs for imported OpenFOAM dictionaries."""
+
+from __future__ import annotations
+
+from difflib import unified_diff
+from pathlib import Path
+import re
+from typing import Any, Optional
+
+from .case_import_source import _read_text, iter_regular_files
+
+
+_FOAM_NUMBER_RE = re.compile(
+    r"(?<![A-Za-z_])[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?(?![A-Za-z_])"
+)
+_NON_NUMERIC_SEMICOLON_KEYS = frozenset(
+    {
+        "application",
+        "continuousPhase",
+        "continuousPhaseName",
+        "runTimeModifiable",
+        "simulationType",
+        "startFrom",
+        "stopAt",
+        "transportModel",
+        "viscosityModel",
+        "writeControl",
+        "writeFormat",
+    }
+)
+
+
+def numeric_signature(content: str) -> dict[str, Any]:
+    """Capture every numeric token and its source-line binding."""
+    tokens = _FOAM_NUMBER_RE.findall(content)
+    bindings: list[tuple[str, tuple[str, ...]]] = []
+    for line in content.splitlines():
+        values = tuple(_FOAM_NUMBER_RE.findall(line))
+        if values:
+            bindings.append((_FOAM_NUMBER_RE.sub("<number>", line), values))
+    return {"tokens": tokens, "bindings": bindings}
+
+
+def numeric_snapshot(case_dir: Path) -> dict[str, dict[str, Any]]:
+    snapshot: dict[str, dict[str, Any]] = {}
+    for path in iter_regular_files(case_dir):
+        if ".foamagent" in path.parts:
+            continue
+        snapshot[path.relative_to(case_dir).as_posix()] = numeric_signature(_read_text(path))
+    return snapshot
+
+
+def _foamfile_object_match(content: str) -> Optional[re.Match[str]]:
+    """Find ``object`` only inside the actual FoamFile header."""
+    foam_file = re.search(r"\bFoamFile\b", content)
+    if not foam_file:
+        return None
+    opening = content.find("{", foam_file.end())
+    if opening < 0:
+        return None
+    depth = 0
+    closing = -1
+    for index in range(opening, len(content)):
+        if content[index] == "{":
+            depth += 1
+        elif content[index] == "}":
+            depth -= 1
+            if depth == 0:
+                closing = index
+                break
+    if closing < 0:
+        return None
+
+    header = content[opening + 1 : closing]
+    comment_free = re.sub(
+        r"/\*.*?\*/|//[^\n]*",
+        lambda match: " " * len(match.group(0)),
+        header,
+        flags=re.DOTALL,
+    )
+    match = re.search(r"\bobject\s+([^\s;]+)(\s*;)", comment_free)
+    if match is None:
+        return None
+    offset = opening + 1
+    return re.compile(r"\bobject\s+([^\s;]+)(\s*;)").search(
+        content,
+        offset + match.start(),
+        offset + match.end(),
+    )
+
+
+def _repair_object_headers(case_dir: Path) -> list[tuple[Path, str, str]]:
+    repairs: list[tuple[Path, str, str]] = []
+    for path in iter_regular_files(case_dir):
+        if ".foamagent" in path.parts or path.name in {"Allrun", "Allclean"}:
+            continue
+        content = _read_text(path)
+        if "FoamFile" not in content:
+            continue
+        match = _foamfile_object_match(content)
+        if not match or match.group(1) == path.name:
+            continue
+        repaired = content[: match.start(1)] + path.name + content[match.end(1) :]
+        repairs.append((path, content, repaired))
+    return repairs
+
+
+def _repair_missing_semicolons(case_dir: Path) -> list[tuple[Path, str, str]]:
+    key_pattern = "|".join(sorted(_NON_NUMERIC_SEMICOLON_KEYS))
+    statement = re.compile(
+        rf"^(?P<prefix>\s*(?:{key_pattern})\s+[^;{{}}()\n]+?)(?P<comment>\s*//.*)?$",
+        re.MULTILINE,
+    )
+    repairs: list[tuple[Path, str, str]] = []
+    for path in iter_regular_files(case_dir):
+        if ".foamagent" in path.parts or path.name in {"Allrun", "Allclean"}:
+            continue
+        content = _read_text(path)
+        if not content:
+            continue
+        repaired = statement.sub(
+            lambda match: f"{match.group('prefix').rstrip()};{match.group('comment') or ''}",
+            content,
+        )
+        if repaired != content:
+            repairs.append((path, content, repaired))
+    return repairs
+
+
+def apply_safe_repairs(work_dir: str | Path, errors: list[Any]) -> list[dict[str, Any]]:
+    """Apply only error-gated repairs that preserve all source numeric inputs."""
+    case_dir = Path(work_dir)
+    error_text = "\n".join(str(error) for error in errors).lower()
+    candidates: list[tuple[Path, str, str]] = []
+    if "object" in error_text or "foamfile" in error_text:
+        candidates.extend(_repair_object_headers(case_dir))
+    if "expected ';'" in error_text or "expected ;" in error_text:
+        candidates.extend(_repair_missing_semicolons(case_dir))
+
+    before = numeric_snapshot(case_dir)
+    records: list[dict[str, Any]] = []
+    for path, old, new in candidates:
+        relative = path.relative_to(case_dir).as_posix()
+        if numeric_signature(old) != numeric_signature(new):
+            records.append(
+                {
+                    "file": relative,
+                    "status": "rejected",
+                    "reason": "repair would alter numeric tokens or their line bindings",
+                }
+            )
+            continue
+        path.write_text(new, encoding="utf-8")
+        records.append(
+            {
+                "file": relative,
+                "status": "applied",
+                "reason": "deterministic non-numeric syntax/header repair",
+                "diff": "".join(
+                    unified_diff(
+                        old.splitlines(keepends=True),
+                        new.splitlines(keepends=True),
+                        fromfile=f"before/{relative}",
+                        tofile=f"after/{relative}",
+                    )
+                ),
+            }
+        )
+    if before != numeric_snapshot(case_dir):
+        raise RuntimeError("Safe repair violated the numeric-invariant check; work copy must be inspected.")
+    return records

--- a/src/services/case_import_source.py
+++ b/src/services/case_import_source.py
@@ -1,0 +1,549 @@
+"""Source validation and materialisation for existing-case import mode."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import tempfile
+from typing import Iterable, Optional
+import zipfile
+
+from .case_import_allrun import (
+    ensure_mesh_check,
+    parse_allrun,
+    synthesise_execution_plan,
+)
+from .case_import_models import CaseImportError, CaseManifest
+from .output_safety import (
+    OutputDirectorySafetyError,
+    prepare_output_directory,
+    validate_output_path,
+)
+
+
+MAX_ARCHIVE_FILES = 10_000
+MAX_ARCHIVE_BYTES = 1_000_000_000
+TEXT_SAMPLE_BYTES = 128_000
+_APPLICATION_RE = re.compile(r"\bapplication\s+([^\s;]+)\s*;")
+_VERSION_RE = re.compile(r"\bVersion\s*:\s*([vV]?\d+(?:\.\d+)?)")
+_CONTROL_ENTRY_RE = re.compile(r"\b(?P<key>startFrom|startTime)\s+(?P<value>[^\s;]+)\s*;")
+_TIME_DIRECTORY_RE = re.compile(r"^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?$")
+_SAFE_COMMAND_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+_FORBIDDEN_DYNAMIC_CODE_RE = re.compile(
+    r"#\s*(?:codeStream|include|includeEtc|includeFunc)\b|"
+    r"\b(?:coded|codeExecute|codeInclude|codeLibs|codeOptions)\b",
+    re.IGNORECASE,
+)
+_LIBRARY_DECLARATION_RE = re.compile(r"\blibs\s*\(", re.IGNORECASE)
+
+
+def _read_text(path: Path, *, limit: Optional[int] = None) -> str:
+    try:
+        with path.open("rb") as handle:
+            data = handle.read(limit) if limit is not None else handle.read()
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _strip_foam_comments(content: str) -> str:
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    return re.sub(r"//.*$", "", content, flags=re.MULTILINE)
+
+
+def _control_dict_application(case_root: Path) -> str:
+    content = _strip_foam_comments(_read_text(case_root / "system" / "controlDict"))
+    match = _APPLICATION_RE.search(content)
+    if not match:
+        raise CaseImportError(
+            "system/controlDict does not define an application; cannot identify the solver."
+        )
+    application = match.group(1)
+    if not _SAFE_COMMAND_RE.fullmatch(application):
+        raise CaseImportError(f"Unsupported application token in system/controlDict: {application!r}.")
+    return application
+
+
+def _synthesised_startup_issue(case_root: Path) -> Optional[str]:
+    """Reject inferred plans with an unsatisfied restart dependency."""
+    content = _strip_foam_comments(_read_text(case_root / "system" / "controlDict"))
+    entries = {match.group("key"): match.group("value") for match in _CONTROL_ENTRY_RE.finditer(content)}
+    start_from = entries.get("startFrom")
+    start_time = entries.get("startTime")
+    time_directories = [
+        path.name
+        for path in case_root.iterdir()
+        if path.is_dir() and _TIME_DIRECTORY_RE.fullmatch(path.name)
+    ]
+
+    if start_from in {"latestTime", "firstTime"}:
+        if not time_directories:
+            return (
+                "Allrun is missing, but controlDict requests "
+                f"startFrom {start_from} with no numeric time directory. "
+                "Provide an explicit Allrun/setup stage."
+            )
+        return None
+    if start_from not in {None, "startTime"} or not start_time:
+        return None
+    try:
+        expected_time = float(start_time)
+    except ValueError:
+        return (
+            "Allrun is missing and controlDict has an unsupported startTime "
+            f"token {start_time!r}; provide an explicit Allrun."
+        )
+    if expected_time == 0 or any(
+        abs(float(directory) - expected_time) <= 1e-12 for directory in time_directories
+    ):
+        return None
+    return (
+        "Allrun is missing, but controlDict starts from time "
+        f"{start_time} and that numeric time directory is absent. "
+        "Provide the required setup stage or an explicit Allrun."
+    )
+
+
+def iter_regular_files(root: Path) -> Iterable[Path]:
+    """Yield case files while rejecting links instead of following them."""
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise CaseImportError(f"Symbolic links are not supported in imported cases: {path}")
+        if path.is_file():
+            yield path
+
+
+def _hash_files(root: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for path in iter_regular_files(root):
+        digest = hashlib.sha256()
+        try:
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        except OSError as exc:
+            raise CaseImportError(f"Unable to hash imported file {path}: {exc}") from exc
+        hashes[path.relative_to(root).as_posix()] = digest.hexdigest()
+    return hashes
+
+
+def _validate_source_tree(root: Path) -> None:
+    if not root.is_dir():
+        raise CaseImportError(f"Case path is not a directory: {root}")
+    file_count = 0
+    total_bytes = 0
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise CaseImportError(f"Symbolic links are not allowed in imported cases: {path}")
+        if path.name == ".foamagent":
+            raise CaseImportError(
+                "Imported cases cannot contain the reserved .foamagent control directory."
+            )
+        if path.is_file():
+            file_count += 1
+            try:
+                total_bytes += path.stat().st_size
+            except OSError as exc:
+                raise CaseImportError(f"Unable to inspect imported file {path}: {exc}") from exc
+            if file_count > MAX_ARCHIVE_FILES:
+                raise CaseImportError(
+                    f"Case contains more than {MAX_ARCHIVE_FILES} files; the import safety limit was exceeded."
+                )
+            if total_bytes > MAX_ARCHIVE_BYTES:
+                raise CaseImportError(
+                    "Case size exceeds the 1 GB import safety limit."
+                )
+
+
+def _normalise_zip_member(member: zipfile.ZipInfo) -> Optional[PurePosixPath]:
+    """Validate one ZIP member path before anything is written to disk."""
+    filename = member.filename
+    if (
+        not filename
+        or "\x00" in filename
+        or "\\" in filename
+        or re.match(r"^[A-Za-z]:", filename)
+    ):
+        raise CaseImportError(f"ZIP entry uses an unsupported Windows path: {filename!r}.")
+    member_path = PurePosixPath(filename)
+    if member_path.is_absolute() or ".." in member_path.parts or filename.startswith(("/", "\\")):
+        raise CaseImportError(f"ZIP entry escapes the import directory: {filename!r}.")
+    if stat.S_ISLNK(member.external_attr >> 16):
+        raise CaseImportError(f"ZIP symbolic links are not supported: {filename!r}.")
+    if not member_path.parts:
+        if member.is_dir():
+            return None
+        raise CaseImportError(f"ZIP entry has an empty path: {filename!r}.")
+    return member_path
+
+
+def _validated_zip_members(
+    members: list[zipfile.ZipInfo],
+) -> list[tuple[zipfile.ZipInfo, PurePosixPath]]:
+    if len(members) > MAX_ARCHIVE_FILES:
+        raise CaseImportError(
+            f"ZIP contains {len(members)} entries; the limit is {MAX_ARCHIVE_FILES}."
+        )
+    if sum(member.file_size for member in members) > MAX_ARCHIVE_BYTES:
+        raise CaseImportError("ZIP uncompressed size exceeds the 1 GB import safety limit.")
+
+    normalised_members: list[tuple[zipfile.ZipInfo, PurePosixPath]] = []
+    seen_members: set[PurePosixPath] = set()
+    for member in members:
+        member_path = _normalise_zip_member(member)
+        if member_path is None:
+            continue
+        if member_path in seen_members:
+            raise CaseImportError(f"ZIP contains duplicate member path: {member.filename!r}.")
+        seen_members.add(member_path)
+        normalised_members.append((member, member_path))
+    return normalised_members
+
+
+def _extract_zip_member(
+    zip_file: zipfile.ZipFile,
+    member: zipfile.ZipInfo,
+    member_path: PurePosixPath,
+    destination: Path,
+    destination_root: Path,
+    extracted_bytes: int,
+) -> int:
+    """Extract one validated member and enforce the runtime archive-size limit."""
+    target = destination.joinpath(*member_path.parts)
+    try:
+        target.resolve().relative_to(destination_root)
+    except ValueError as exc:
+        raise CaseImportError(
+            f"ZIP entry escapes the import directory: {member.filename!r}."
+        ) from exc
+    if member.is_dir():
+        target.mkdir(parents=True, exist_ok=True)
+        return extracted_bytes
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            raise CaseImportError(f"ZIP member conflicts with an existing path: {member.filename!r}.")
+        with zip_file.open(member, "r") as source, target.open("xb") as output:
+            while chunk := source.read(64 * 1024):
+                extracted_bytes += len(chunk)
+                if extracted_bytes > MAX_ARCHIVE_BYTES:
+                    raise CaseImportError("ZIP uncompressed size exceeds the 1 GB import safety limit.")
+                output.write(chunk)
+        return extracted_bytes
+    except CaseImportError:
+        target.unlink(missing_ok=True)
+        raise
+    except OSError as exc:
+        target.unlink(missing_ok=True)
+        raise CaseImportError(f"Unable to extract ZIP member {member.filename!r}: {exc}") from exc
+
+
+def _safe_extract_zip(archive: Path, destination: Path) -> None:
+    """Extract an archive with traversal, link, count, and size checks."""
+    try:
+        with zipfile.ZipFile(archive) as zip_file:
+            members = _validated_zip_members(zip_file.infolist())
+            extracted_bytes = 0
+            destination_root = destination.resolve()
+            for member, member_path in members:
+                extracted_bytes = _extract_zip_member(
+                    zip_file,
+                    member,
+                    member_path,
+                    destination,
+                    destination_root,
+                    extracted_bytes,
+                )
+    except zipfile.BadZipFile as exc:
+        raise CaseImportError(f"Invalid ZIP archive: {archive}") from exc
+
+
+def _find_case_root(source_root: Path, case_subdir: Optional[str]) -> Path:
+    if case_subdir:
+        relative = PurePosixPath(case_subdir.replace("\\", "/"))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise CaseImportError("--case_subdir must be a relative path inside the import.")
+        candidate = (source_root / Path(*relative.parts)).resolve()
+        try:
+            candidate.relative_to(source_root.resolve())
+        except ValueError as exc:
+            raise CaseImportError("--case_subdir escapes the imported source.") from exc
+        if not (candidate / "system" / "controlDict").is_file():
+            raise CaseImportError(f"--case_subdir={case_subdir!r} does not contain system/controlDict.")
+        return candidate
+
+    candidates = sorted(
+        control.parent.parent
+        for control in source_root.rglob("controlDict")
+        if control.parent.name == "system" and control.is_file()
+    )
+    if not candidates:
+        raise CaseImportError("No system/controlDict found in the imported case.")
+    if len(candidates) > 1:
+        listed = ", ".join(str(candidate.relative_to(source_root)) for candidate in candidates[:8])
+        raise CaseImportError(
+            "Multiple OpenFOAM cases found in the import. Specify --case_subdir. "
+            f"Candidates: {listed}"
+        )
+    return candidates[0]
+
+
+def _detect_platform(case_root: Path) -> tuple[str, Optional[str]]:
+    evidence_paths = [case_root / "system" / "controlDict"]
+    evidence_paths.extend(
+        path
+        for path in iter_regular_files(case_root)
+        if path.name in {"blockMeshDict", "fvSolution", "fvSchemes"} and path not in evidence_paths
+    )
+    contents = "\n".join(_read_text(path, limit=TEXT_SAMPLE_BYTES) for path in evidence_paths)
+    lowered = contents.lower()
+    version_match = _VERSION_RE.search(contents)
+    version = version_match.group(1) if version_match else None
+    if "openfoam.com" in lowered:
+        return "esi", version
+    if "openfoam.org" in lowered:
+        return ("foundation-v10", version) if version and version.lstrip("vV") == "10" else ("foundation-other", version)
+
+    constant_dir = case_root / "constant"
+    if any(constant_dir.glob("momentumTransport*")):
+        return "foundation-v10-compatible", version
+    if (constant_dir / "turbulenceProperties").exists() or any(constant_dir.glob("turbulenceProperties.*")):
+        return "unknown", version
+    return "unknown", version
+
+
+def _mesh_state(case_root: Path) -> str:
+    if (case_root / "constant" / "polyMesh").is_dir():
+        return "existing-polyMesh"
+    if (case_root / "system" / "blockMeshDict").is_file():
+        return "blockMesh"
+    return "missing"
+
+
+def _extract_libraries(case_root: Path) -> list[str]:
+    libraries: set[str] = set()
+    for path in _dependency_scan_files(case_root):
+        content = _strip_foam_comments(_read_text(path, limit=TEXT_SAMPLE_BYTES))
+        for block in re.findall(r"\blibs\s*\((.*?)\)", content, re.DOTALL):
+            libraries.update(re.findall(r'["\']([^"\']+\.so)["\']', block))
+    return sorted(libraries)
+
+
+def _dependency_scan_files(case_root: Path) -> Iterable[Path]:
+    """Yield only dictionary inputs which can affect imported-case execution.
+
+    Imported archives often contain README files, notes, and patch artefacts.
+    Those files are not interpreted by OpenFOAM, so wording such as ``coded``
+    or ``#include`` in them must not block an otherwise safe case.
+    """
+    for path in iter_regular_files(case_root):
+        relative = path.relative_to(case_root)
+        if path.name == "Allrun":
+            yield path
+            continue
+        if relative.parts and relative.parts[0] in {"0", "constant", "system"}:
+            yield path
+            continue
+        if relative.parts and _TIME_DIRECTORY_RE.fullmatch(relative.parts[0]):
+            yield path
+
+
+def _iter_comment_free_chunks(path: Path) -> Iterable[str]:
+    """Stream OpenFOAM text with ``//`` and ``/* ... */`` comments removed."""
+    in_block_comment = False
+    in_line_comment = False
+    pending = ""
+    try:
+        with path.open("rb") as handle:
+            while raw_chunk := handle.read(64 * 1024):
+                text = pending + raw_chunk.decode("utf-8", errors="replace")
+                pending = ""
+                output: list[str] = []
+                index = 0
+                # Retain one unprocessed character for the next chunk so a
+                # comment opener or closer split at the I/O boundary is still
+                # recognised as a two-character token.
+                while index < len(text) - 1:
+                    character = text[index]
+                    following = text[index + 1]
+                    if in_line_comment:
+                        if character == "\n":
+                            in_line_comment = False
+                            output.append(character)
+                        index += 1
+                    elif in_block_comment:
+                        if character == "*" and following == "/":
+                            in_block_comment = False
+                            index += 2
+                        else:
+                            if character == "\n":
+                                output.append(character)
+                            index += 1
+                    elif character == "/" and following == "/":
+                        in_line_comment = True
+                        index += 2
+                    elif character == "/" and following == "*":
+                        in_block_comment = True
+                        index += 2
+                    else:
+                        output.append(character)
+                        index += 1
+                pending = text[index:]
+                if output:
+                    yield "".join(output)
+            if pending:
+                if in_line_comment:
+                    if pending == "\n":
+                        yield pending
+                elif not in_block_comment:
+                    yield pending
+    except OSError as exc:
+        raise CaseImportError(f"Unable to inspect imported file {path}: {exc}") from exc
+
+
+def _file_contains_pattern(path: Path, pattern: re.Pattern[str]) -> bool:
+    overlap = ""
+    for chunk in _iter_comment_free_chunks(path):
+        text = overlap + chunk
+        if pattern.search(text):
+            return True
+        overlap = text[-512:]
+    return False
+
+
+def _detect_custom_dependencies(case_root: Path, allrun_content: str) -> list[str]:
+    issues: list[str] = []
+    if any(path.name in {"Make", "Allwmake"} for path in case_root.rglob("*")):
+        issues.append("case contains a Make/ or Allwmake build dependency")
+    if re.search(r"\b(?:wmake|make|cmake)\b", allrun_content):
+        issues.append("Allrun requests compilation")
+
+    for path in _dependency_scan_files(case_root):
+        if _file_contains_pattern(path, _FORBIDDEN_DYNAMIC_CODE_RE):
+            issues.append(f"dynamic code found in {path.relative_to(case_root)}")
+            break
+    libraries = _extract_libraries(case_root)
+    if libraries or any(
+        _file_contains_pattern(path, _LIBRARY_DECLARATION_RE)
+        for path in _dependency_scan_files(case_root)
+    ):
+        issues.append(
+            "case declares dynamically loaded libraries, which are not supported "
+            "by safe case-import mode: "
+            + (", ".join(libraries) if libraries else "unparsed declaration")
+        )
+    return issues
+
+
+def _write_json(path: Path, value: object) -> None:
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _make_tree_read_only(root: Path) -> None:
+    # Copy ``work/`` before this function is called.  Marking directories as
+    # read-only matters too: a read-only file may still be deleted or replaced
+    # when its parent directory remains writable.
+    paths = [root, *root.rglob("*")]
+    for path in reversed(paths):
+        if path.is_symlink():
+            continue
+        try:
+            path.chmod(path.stat().st_mode & ~0o222)
+        except OSError:
+            pass
+
+
+def import_case(
+    case_path: str | Path,
+    output_dir: str | Path,
+    *,
+    case_subdir: Optional[str] = None,
+    overwrite: bool = False,
+) -> CaseManifest:
+    """Validate a source then materialise ``original/``, ``work/``, and ``report/``."""
+    source_path = Path(case_path).expanduser().resolve()
+    if not source_path.exists():
+        raise CaseImportError(f"Case input does not exist: {source_path}")
+    if not source_path.is_dir() and source_path.suffix.lower() != ".zip":
+        raise CaseImportError("--case_path must reference a directory or a .zip archive.")
+    try:
+        output_root = validate_output_path(output_dir, source_path=source_path)
+    except OutputDirectorySafetyError as exc:
+        raise CaseImportError(str(exc)) from exc
+
+    with tempfile.TemporaryDirectory(prefix="foamagent-case-import-") as temporary:
+        staging = Path(temporary) / "source"
+        if source_path.is_dir():
+            _validate_source_tree(source_path)
+            shutil.copytree(source_path, staging)
+        else:
+            staging.mkdir(parents=True)
+            _safe_extract_zip(source_path, staging)
+            _validate_source_tree(staging)
+        selected_root = _find_case_root(staging, case_subdir)
+        selected_root_relative = selected_root.relative_to(staging)
+
+        platform, version = _detect_platform(selected_root)
+        application = _control_dict_application(selected_root)
+        source_allrun = selected_root / "Allrun"
+        allrun_content = _read_text(source_allrun) if source_allrun.is_file() else ""
+        blocking_issues = _detect_custom_dependencies(selected_root, allrun_content)
+        try:
+            mesh_state = _mesh_state(selected_root)
+            plan = (
+                parse_allrun(allrun_content, application)
+                if source_allrun.is_file()
+                else synthesise_execution_plan(application, mesh_state)
+            )
+            if not source_allrun.is_file() and (startup_issue := _synthesised_startup_issue(selected_root)):
+                blocking_issues.append(startup_issue)
+            plan = ensure_mesh_check(plan, application)
+        except CaseImportError as exc:
+            blocking_issues.append(str(exc))
+            plan = []
+        if platform not in {"foundation-v10", "foundation-v10-compatible"}:
+            blocking_issues.append(
+                "Only Foundation OpenFOAM v10 cases are supported by case-import mode; "
+                f"detected platform is {platform}{f' ({version})' if version else ''}."
+            )
+
+        try:
+            output_root = prepare_output_directory(output_root, overwrite=overwrite, source_path=source_path)
+        except (FileExistsError, OutputDirectorySafetyError) as exc:
+            raise CaseImportError(str(exc)) from exc
+
+        original_dir = output_root / "original"
+        work_dir = output_root / "work"
+        report_dir = output_root / "report"
+        original_staging_dir = output_root / ".original-staging"
+        try:
+            shutil.copytree(selected_root, original_staging_dir)
+            original_staging_dir.rename(original_dir)
+        except OSError as exc:
+            shutil.rmtree(original_staging_dir, ignore_errors=True)
+            raise CaseImportError(f"Unable to materialize imported case: {exc}") from exc
+
+        manifest = CaseManifest(
+            source=str(source_path),
+            case_root=str(selected_root_relative),
+            output_root=str(output_root),
+            platform=platform,
+            version=version,
+            application=application,
+            allrun_provided=source_allrun.is_file(),
+            mesh_state=_mesh_state(original_dir),
+            execution_plan=plan,
+            detected_libraries=_extract_libraries(original_dir),
+            blocking_issues=list(dict.fromkeys(blocking_issues)),
+            original_hashes=_hash_files(original_dir),
+        )
+        shutil.copytree(original_dir, work_dir)
+        _make_tree_read_only(original_dir)
+        _write_json(report_dir / "case_manifest.json", manifest.to_dict())
+        return manifest

--- a/src/services/case_paths.py
+++ b/src/services/case_paths.py
@@ -1,0 +1,59 @@
+"""Contain untrusted generated file names within an OpenFOAM case root."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+
+class CasePathSafetyError(ValueError):
+    """Raised when a case-relative path could escape the intended case root."""
+
+
+def _normalise_component(value: str, *, label: str, allow_empty: bool = False) -> PurePosixPath:
+    if not isinstance(value, str):
+        raise CasePathSafetyError(f"{label} must be a string")
+    if "\x00" in value:
+        raise CasePathSafetyError(f"{label} contains a NUL byte")
+    value = value.replace("\\", "/").strip()
+    if not value:
+        if allow_empty:
+            return PurePosixPath(".")
+        raise CasePathSafetyError(f"{label} cannot be empty")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise CasePathSafetyError(f"{label} must be a safe relative path: {value!r}")
+    if path.parts and path.parts[0].endswith(":"):
+        raise CasePathSafetyError(f"{label} must not use a Windows drive path: {value!r}")
+    return path
+
+
+def safe_case_relative_path(folder_name: str, file_name: str) -> PurePosixPath:
+    """Validate a folder/file pair and return its canonical relative path."""
+    folder = _normalise_component(folder_name, label="folder_name", allow_empty=True)
+    file_path = _normalise_component(file_name, label="file_name")
+    if len(file_path.parts) != 1:
+        raise CasePathSafetyError("file_name must be a basename, not a nested path")
+    relative = folder / file_path
+    if relative == PurePosixPath("."):
+        raise CasePathSafetyError("file_name cannot resolve to the case root")
+    return relative
+
+
+def safe_case_path(case_dir: str | Path, folder_name: str, file_name: str) -> Path:
+    """Return a validated path guaranteed to remain under ``case_dir``."""
+    case_root = Path(case_dir).expanduser().resolve()
+    relative = safe_case_relative_path(folder_name, file_name)
+    target = (case_root / Path(*relative.parts)).resolve()
+    try:
+        target.relative_to(case_root)
+    except ValueError as exc:
+        raise CasePathSafetyError(
+            f"Generated path escapes case directory: {relative.as_posix()}"
+        ) from exc
+    return target
+
+
+def safe_case_relative_from_text(value: str) -> PurePosixPath:
+    """Validate a ``folder/file`` target from a rewrite plan."""
+    # Root-level files such as Allrun are legitimate rewrite targets.
+    return _normalise_component(value, label="rewrite target")

--- a/src/services/input_writer.py
+++ b/src/services/input_writer.py
@@ -3,7 +3,24 @@ import re
 from typing import Dict, List, Any, Optional, Callable
 import shutil
 from utils import save_file, parse_context, retrieve_faiss, FoamPydantic, FoamfilePydantic, scan_case_directory, read_case_foamfiles, read_file
+from config import Config
+from pydantic import BaseModel, Field
 from . import global_llm_service
+from .case_paths import (
+    CasePathSafetyError,
+    safe_case_path,
+    safe_case_relative_from_text,
+    safe_case_relative_path,
+)
+from .allrun_commands import (
+    allrun_uses_runfunctions,
+    invoked_command,
+    is_run_wrapper,
+    line_invokes_command,
+    line_invokes_solver,
+    shell_tokens,
+)
+from .openfoam_commands import MESH_MUTATING_COMMANDS
 
 
 def compute_priority(subtask):
@@ -15,6 +32,193 @@ def compute_priority(subtask):
         return 2
     else:
         return 3
+
+
+def _report_progress(
+    callback: Optional[Callable[[int, int, str], None]],
+    current: int,
+    total: int,
+    message: str,
+) -> None:
+    """Notify an optional observer without letting UI updates stop generation."""
+    if callback is None:
+        return
+    try:
+        callback(current, total, message)
+    except Exception as exc:  # noqa: BLE001 - callback implementation is external
+        print(f"<progress_callback_error>{exc}</progress_callback_error>")
+
+
+def _generation_contract(openfoam_fork: str) -> str:
+    """Return version/fork constraints shared by initial writes and rewrites.
+
+    The contract is intentionally solver-level rather than case-level: it contains
+    no geometry, material, boundary, or operating values from a particular case.
+    """
+    fork = (openfoam_fork or "foundation").strip().lower()
+    if fork == "foundation":
+        constraints = [
+            "The target runtime is Foundation OpenFOAM v10 from openfoam.org.",
+            "Use only Foundation OpenFOAM v10 solver, file, field, dictionary, and boundary-condition conventions.",
+            "Do not use or mix in ESI/OpenCFD openfoam.com conventions from versioned releases such as v20xx, v21xx, v22xx, v23xx, or v24xx.",
+            "If a reference case conflicts with Foundation OpenFOAM v10, ignore the conflicting syntax and follow Foundation v10.",
+            "For blockMesh boundary dictionaries, every symmetryPlane patch must contain only coplanar faces. For a pair of parallel but spatially separate symmetry faces, either use the generic symmetry patch type or create one symmetryPlane patch per plane.",
+            "When a Foundation momentumTransport or momentumTransport.<phase> dictionary is generated, it must declare simulationType (for example, laminar when the prompt requests laminar flow) before its model coefficients.",
+        ]
+    elif fork == "esi":
+        constraints = [
+            "The configured target runtime is ESI/OpenCFD OpenFOAM from openfoam.com.",
+            "Use ESI-compatible solver, file, field, dictionary, and boundary-condition conventions consistently.",
+            "Do not mix Foundation-only conventions into the generated files.",
+        ]
+    else:
+        constraints = [
+            f"The configured OpenFOAM fork is {fork!r}.",
+            "Keep all generated files internally consistent with that configured fork and do not mix conventions from another fork.",
+        ]
+
+    return "\n".join(f"- {constraint}" for constraint in constraints)
+
+
+_INITIAL_WRITE_SYSTEM_PROMPT = (
+    "You are an expert in OpenFOAM simulation and numerical modeling."
+    "Your task is to generate a complete and functional file named: <file_name>{file_name}</file_name> within the <folder_name>{folder_name}</folder_name> directory. "
+    "Ensure all required values are present and match with the files content already generated."
+    "Before finalizing the output, ensure:\n"
+    "- All necessary fields exist (e.g., if `nu` is defined in `constant/transportProperties`, it must be used correctly in `0/U`).\n"
+    "- Cross-check field names between different files to avoid mismatches.\n"
+    "- Ensure units and dimensions are correct** for all physical variables.\n"
+    "- Ensure case solver settings are consistent with the user's requirements. The selected solver is: {case_solver}.\n"
+    "OpenFOAM compatibility contract:\n"
+    "{generation_contract}\n"
+    "Provide only the code—no explanations, comments, or additional text."
+)
+
+
+def _normalise_initial_subtask(subtask: Dict[str, str]) -> Dict[str, str]:
+    """Validate one generation target and store it as a case-relative path."""
+    if not isinstance(subtask, dict):
+        raise ValueError(f"Invalid subtask format: {subtask!r}")
+    try:
+        relative = safe_case_relative_path(
+            subtask.get("folder_name", ""),
+            subtask.get("file_name", ""),
+        )
+    except CasePathSafetyError as exc:
+        raise ValueError(f"Unsafe generated subtask path: {subtask!r}") from exc
+    normalized = dict(subtask)
+    normalized["folder_name"] = "" if relative.parent.as_posix() == "." else relative.parent.as_posix()
+    normalized["file_name"] = relative.name
+    return normalized
+
+
+def _initial_file_prompts(
+    *,
+    file_name: str,
+    folder_name: str,
+    case_solver: str,
+    generation_contract: str,
+    user_requirement: str,
+    tutorial_reference: str,
+    similar_case_advice: Optional[Any],
+    generation_mode: str,
+    written_files: List[FoamfilePydantic],
+) -> tuple[str, str]:
+    """Build one file-generation prompt with only the needed prior context."""
+    system_prompt = _INITIAL_WRITE_SYSTEM_PROMPT.format(
+        file_name=file_name,
+        folder_name=folder_name,
+        case_solver=case_solver,
+        generation_contract=generation_contract,
+    )
+    if isinstance(similar_case_advice, dict):
+        advice_text = (
+            f"Similar case match level: {similar_case_advice.get('match_level')}\n"
+            f"Use scope: {similar_case_advice.get('use_scope')}\n"
+            f"Advice: {similar_case_advice.get('advice')}\n"
+        )
+    else:
+        advice_text = str(similar_case_advice or "")
+    similar_reference = (
+        f"Refer to the following similar case file content if helpful:\n<similar_case_reference>{tutorial_reference}</similar_case_reference>\n"
+        if tutorial_reference
+        else "No suitable similar case was found for this domain.\n"
+    )
+    user_prompt = (
+        f"User requirement: {user_requirement}\n"
+        f"{similar_reference}{advice_text}\n"
+        "If the similar case is a weak match, do not copy it blindly. Use it only where it is consistent with the user requirement. "
+        "The OpenFOAM compatibility contract in the system prompt takes precedence over incompatible syntax in a reference case. "
+        "Just modify the necessary parts to make the file complete and functional."
+        "Please ensure that the generated file is complete, functional, and logically sound."
+        "Additionally, apply your domain expertise to verify that all numerical values are consistent with the user's requirements, maintaining accuracy and coherence."
+        "When generating controlDict, do not include anything to preform post processing. Just include the necessary settings to run the simulation."
+    )
+    if file_name == "fvSolution":
+        user_prompt += (
+            "\n\nCRITICAL for transient pressure-velocity coupling solvers using PISO/PIMPLE: "
+            "the solvers dictionary must include matching Final solver entries for fields used on the final correction. "
+            "For example, if p is defined, include pFinal { $p; relTol 0; }; "
+            "if U is defined, include UFinal { $U; relTol 0; }. "
+            "For grouped regex entries, use the matching grouped Final entry, e.g. "
+            "\"(U|k|epsilon)Final\" { $U; relTol 0; }. "
+            "Do not emit placeholder text such as $<field>; in the generated file. "
+            "Also ensure the PIMPLE/PISO sub-dictionary matches the selected solver."
+        )
+    if generation_mode == "sequential_dependency" and written_files:
+        user_prompt += (
+            f"The following are files content already generated: {written_files}\n\n\n"
+            "You should ensure that the new file is consistent with the previous files. Such as boundary conditions, mesh settings, etc."
+        )
+    return user_prompt, system_prompt
+
+
+def _generate_initial_file(
+    subtask: Dict[str, str],
+    *,
+    case_dir: str,
+    reuse_generated_dir: str,
+    llm_client: Any,
+    case_solver: str,
+    generation_contract: str,
+    user_requirement: str,
+    tutorial_reference: str,
+    similar_case_advice: Optional[Any],
+    generation_mode: str,
+    written_files: List[FoamfilePydantic],
+) -> FoamfilePydantic:
+    """Generate or safely reuse a single OpenFOAM dictionary."""
+    file_name = subtask["file_name"]
+    folder_name = subtask["folder_name"]
+    try:
+        file_path = safe_case_path(case_dir, folder_name, file_name)
+    except CasePathSafetyError as exc:
+        raise ValueError(f"Unsafe generated subtask path: {subtask!r}") from exc
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    if reuse_generated_dir:
+        reuse_source = safe_case_path(reuse_generated_dir, folder_name, file_name)
+        if reuse_source.exists():
+            print(f"Reusing generated file: {reuse_source}")
+            shutil.copy2(reuse_source, file_path)
+            return FoamfilePydantic(
+                file_name=file_name,
+                folder_name=folder_name,
+                content=read_file(str(reuse_source)),
+            )
+    user_prompt, system_prompt = _initial_file_prompts(
+        file_name=file_name,
+        folder_name=folder_name,
+        case_solver=case_solver,
+        generation_contract=generation_contract,
+        user_requirement=user_requirement,
+        tutorial_reference=tutorial_reference,
+        similar_case_advice=similar_case_advice,
+        generation_mode=generation_mode,
+        written_files=written_files,
+    )
+    content = parse_context(llm_client.invoke(user_prompt, system_prompt))
+    save_file(str(file_path), content)
+    return FoamfilePydantic(file_name=file_name, folder_name=folder_name, content=content)
 
 
 def initial_write(
@@ -33,6 +237,9 @@ def initial_write(
     similar_case_advice: Optional[Any] = None,
     reuse_generated_dir: str = "",
     progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    openfoam_fork: str = "foundation",
+    llm_service: Optional[Any] = None,
+    config: Optional[Config] = None,
 ) -> Dict[str, Any]:
     """
     Generate OpenFOAM files from scratch based on user requirements and subtasks.
@@ -56,6 +263,7 @@ def initial_write(
         mesh_commands (List[str], optional): Custom mesh commands. Defaults to None.
         database_path (str, optional): Path to FAISS database for command lookup. Defaults to "".
         searchdocs (int, optional): Number of documents to search for commands. Defaults to 2.
+        openfoam_fork (str, optional): Target OpenFOAM fork. Defaults to "foundation".
     
     Returns:
         Dict[str, Any]: Contains:
@@ -83,13 +291,7 @@ def initial_write(
         >>> print(f"Generated {len(result['dir_structure'])} directories")
     """
     print("<initial_write_service>")
-
-    def _report_progress(current: int, total: int, message: str) -> None:
-        if progress_callback:
-            try:
-                progress_callback(current, total, message)
-            except Exception:
-                pass
+    llm_client = llm_service if llm_service is not None else global_llm_service
 
     if generation_mode not in {"sequential_dependency", "parallel_no_context"}:
         raise ValueError(
@@ -97,110 +299,31 @@ def initial_write(
             "Expected one of: sequential_dependency, parallel_no_context"
         )
 
-    subtasks = sorted(subtasks, key=compute_priority)
+    subtasks = sorted(
+        (_normalise_initial_subtask(item) for item in subtasks),
+        key=compute_priority,
+    )
+    seen_targets: set[tuple[str, str]] = set()
+    for subtask in subtasks:
+        target = (subtask["folder_name"], subtask["file_name"])
+        if target in seen_targets:
+            relative = "/".join(part for part in target if part)
+            raise ValueError(f"Duplicate generated subtask target: {relative}")
+        seen_targets.add(target)
     written_files = []
     dir_structure = {}
-
-    # System prompt for file generation
-    INITIAL_WRITE_SYSTEM_PROMPT = (
-        "You are an expert in OpenFOAM simulation and numerical modeling."
-        f"Your task is to generate a complete and functional file named: <file_name>{{file_name}}</file_name> within the <folder_name>{{folder_name}}</folder_name> directory. "
-        "Ensure all required values are present and match with the files content already generated."
-        "Before finalizing the output, ensure:\n"
-        "- All necessary fields exist (e.g., if `nu` is defined in `constant/transportProperties`, it must be used correctly in `0/U`).\n"
-        "- Cross-check field names between different files to avoid mismatches.\n"
-        "- Ensure units and dimensions are correct** for all physical variables.\n"
-        f"- Ensure case solver settings are consistent with the user's requirements. Available solvers are: {{case_solver}}.\n"
-        "Provide only the code—no explanations, comments, or additional text."
-    )
-
-    def _build_prompts(file_name: str, folder_name: str, written_files_ctx: List[FoamfilePydantic]) -> tuple[str, str]:
-        code_system_prompt = INITIAL_WRITE_SYSTEM_PROMPT.format(
-            file_name=file_name,
-            folder_name=folder_name,
-            case_solver=case_solver,
-        )
-
-        advice_text = ""
-        if isinstance(similar_case_advice, dict):
-            advice_text = (
-                f"Similar case match level: {similar_case_advice.get('match_level')}\n"
-                f"Use scope: {similar_case_advice.get('use_scope')}\n"
-                f"Advice: {similar_case_advice.get('advice')}\n"
-            )
-        elif similar_case_advice:
-            advice_text = str(similar_case_advice)
-
-        similar_ref_block = (
-            f"Refer to the following similar case file content if helpful:\n<similar_case_reference>{tutorial_reference}</similar_case_reference>\n"
-            if tutorial_reference else "No suitable similar case was found for this domain.\n"
-        )
-
-        code_user_prompt = (
-            f"User requirement: {user_requirement}\n"
-            f"{similar_ref_block}"
-            f"{advice_text}"
-            "If the similar case is a weak match, do not copy it blindly. Use it only where it is consistent with the user requirement. "
-            "Just modify the necessary parts to make the file complete and functional."
-            "Please ensure that the generated file is complete, functional, and logically sound."
-            "Additionally, apply your domain expertise to verify that all numerical values are consistent with the user's requirements, maintaining accuracy and coherence."
-            "When generating controlDict, do not include anything to preform post processing. Just include the necessary settings to run the simulation."
-        )
-
-        if file_name == "fvSolution":
-            code_user_prompt += (
-                "\n\nCRITICAL for transient pressure-velocity coupling solvers using PISO/PIMPLE: "
-                "the solvers dictionary must include matching Final solver entries for fields used on the final correction. "
-                "For example, if p is defined, include pFinal { $p; relTol 0; }; "
-                "if U is defined, include UFinal { $U; relTol 0; }. "
-                "For grouped regex entries, use the matching grouped Final entry, e.g. "
-                "\"(U|k|epsilon)Final\" { $U; relTol 0; }. "
-                "Do not emit placeholder text such as $<field>; in the generated file. "
-                "Also ensure the PIMPLE/PISO sub-dictionary matches the selected solver."
-            )
-
-        if generation_mode == "sequential_dependency" and written_files_ctx:
-            code_user_prompt += (
-                f"The following are files content already generated: {str(written_files_ctx)}\n\n\n"
-                "You should ensure that the new file is consistent with the previous files. Such as boundary conditions, mesh settings, etc."
-            )
-
-        return code_user_prompt, code_system_prompt
-
-    def _generate_one(subtask: Dict[str, str], written_files_ctx: List[FoamfilePydantic]) -> FoamfilePydantic:
-        file_name = subtask["file_name"]
-        folder_name = subtask["folder_name"]
-        if not file_name or not folder_name:
-            raise ValueError(f"Invalid subtask format: {subtask}")
-
-        # Target output path (this run)
-        file_path = os.path.join(case_dir, folder_name, file_name)
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
-
-        # Optional reuse: if a pre-generated file exists, copy it into output and
-        # treat it as a written file (also included in context for subsequent generations).
-        if reuse_generated_dir:
-            reuse_src = os.path.join(reuse_generated_dir, folder_name, file_name)
-            if os.path.exists(reuse_src):
-                print(f"Reusing generated file: {reuse_src}")
-                shutil.copy2(reuse_src, file_path)
-                reused_content = read_file(reuse_src)
-                return FoamfilePydantic(file_name=file_name, folder_name=folder_name, content=reused_content)
-
-        code_user_prompt, code_system_prompt = _build_prompts(file_name, folder_name, written_files_ctx)
-
-        if generation_mode == "parallel_no_context":
-            # Avoid shared global LLM instance in parallel mode.
-            from utils import LLMService
-            from config import Config
-            llm = LLMService(Config())
-            generation_response = llm.invoke(code_user_prompt, code_system_prompt)
-        else:
-            generation_response = global_llm_service.invoke(code_user_prompt, code_system_prompt)
-
-        code_context = parse_context(generation_response)
-        save_file(file_path, code_context)
-        return FoamfilePydantic(file_name=file_name, folder_name=folder_name, content=code_context)
+    generation_contract = _generation_contract(openfoam_fork)
+    file_generation_options = {
+        "case_dir": case_dir,
+        "reuse_generated_dir": reuse_generated_dir,
+        "llm_client": llm_client,
+        "case_solver": case_solver,
+        "generation_contract": generation_contract,
+        "user_requirement": user_requirement,
+        "tutorial_reference": tutorial_reference,
+        "similar_case_advice": similar_case_advice,
+        "generation_mode": generation_mode,
+    }
 
     # Build dir_structure upfront (deterministic ordering) and generate files
     for subtask in subtasks:
@@ -211,7 +334,12 @@ def initial_write(
         dir_structure[folder_name].append(file_name)
 
     total_steps = len(subtasks) + (2 if database_path else 0)
-    _report_progress(0, total_steps, f"Starting file generation for {len(subtasks)} files")
+    _report_progress(
+        progress_callback,
+        0,
+        total_steps,
+        f"Starting file generation for {len(subtasks)} files",
+    )
 
     if generation_mode == "parallel_no_context":
         print("<generation_mode>parallel_no_context (no cross-file context)</generation_mode>")
@@ -224,7 +352,12 @@ def initial_write(
         count_lock = threading.Lock()
         with ThreadPoolExecutor(max_workers=min(32, max(4, len(subtasks)))) as ex:
             future_map = {
-                ex.submit(_generate_one, subtasks[i], []): i
+                ex.submit(
+                    _generate_initial_file,
+                    subtasks[i],
+                    written_files=[],
+                    **file_generation_options,
+                ): i
                 for i in range(len(subtasks))
             }
             for fut in as_completed(future_map):
@@ -233,6 +366,7 @@ def initial_write(
                 with count_lock:
                     completed_count += 1
                     _report_progress(
+                        progress_callback,
                         completed_count, total_steps,
                         f"Generated {subtasks[i]['file_name']} in {subtasks[i]['folder_name']} (parallel)"
                     )
@@ -245,9 +379,18 @@ def initial_write(
             file_name = subtask["file_name"]
             folder_name = subtask["folder_name"]
             print(f"<generating_file>{file_name} in folder: {folder_name}</generating_file>")
-            foamfile = _generate_one(subtask, written_files)
+            foamfile = _generate_initial_file(
+                subtask,
+                written_files=written_files,
+                **file_generation_options,
+            )
             written_files.append(foamfile)
-            _report_progress(idx + 1, total_steps, f"Generated {file_name} in {folder_name}")
+            _report_progress(
+                progress_callback,
+                idx + 1,
+                total_steps,
+                f"Generated {file_name} in {folder_name}",
+            )
     
     # Generate Allrun script if database_path is provided
     if database_path:
@@ -257,12 +400,456 @@ def initial_write(
             progress_callback=progress_callback,
             progress_offset=len(subtasks),
             total_steps=total_steps,
+            llm_service=llm_client,
+            config=config,
         )
-        written_files.append(FoamfilePydantic(file_name="Allrun", folder_name=case_dir, content=allrun_result["allrun_script"]))
+        # ``FoamfilePydantic`` stores paths relative to ``case_dir``.  Keeping
+        # Allrun at the case root makes this entry safe to reuse in a later
+        # rewrite pass instead of embedding an absolute output directory.
+        written_files.append(
+            FoamfilePydantic(
+                file_name="Allrun",
+                folder_name="",
+                content=allrun_result["allrun_script"],
+            )
+        )
     
     foamfiles = FoamPydantic(list_foamfile=written_files)
     print("</initial_write_service>")
     return {"dir_structure": dir_structure, "foamfiles": foamfiles}
+
+
+_MESH_DICTIONARY_COMMANDS = (
+    ("blockMeshDict", "blockMesh"),
+    ("snappyHexMeshDict", "snappyHexMesh"),
+    ("extrudeMeshDict", "extrudeMesh"),
+)
+_MESH_GENERATION_COMMANDS = set(MESH_MUTATING_COMMANDS)
+
+
+def _extract_case_solver(case_info: str) -> str:
+    text = str(case_info or "")
+    patterns = (
+        r"case\s+solver\s*:\s*['\"]?([A-Za-z_][A-Za-z0-9_.+-]*)",
+        r"['\"]case_solver['\"]\s*:\s*['\"]([A-Za-z_][A-Za-z0-9_.+-]*)['\"]",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _dir_structure_contains(dir_structure: Dict[str, List[str]], file_name: str) -> bool:
+    return any(file_name in (files or []) for files in (dir_structure or {}).values())
+
+
+def _format_allrun_command(command: str, use_run_application: bool) -> str:
+    command = command.strip()
+    if not command:
+        return ""
+    if command.startswith(("runApplication ", "runParallel ")):
+        return command
+    if use_run_application:
+        return f"runApplication {command}"
+    return command
+
+
+def _ensure_runfunctions_logging(lines: List[str], solver: str) -> List[str]:
+    """Wrap direct OpenFOAM commands so their per-command logs are retained."""
+    logged_commands = set(_MESH_GENERATION_COMMANDS)
+    logged_commands.add("checkMesh")
+    if solver:
+        logged_commands.add(solver)
+
+    normalized: List[str] = []
+    for line in lines:
+        tokens = shell_tokens(line)
+        if tokens and tokens[0] in logged_commands:
+            leading = line[: len(line) - len(line.lstrip())]
+            line = f"{leading}runApplication {line.lstrip()}"
+        normalized.append(line)
+
+    uses_run_functions = any(is_run_wrapper(line) for line in normalized)
+    has_run_functions_source = allrun_uses_runfunctions(normalized)
+    if uses_run_functions and not has_run_functions_source:
+        insert_at = 1 if normalized and normalized[0].lstrip().startswith("#!") else 0
+        normalized.insert(insert_at, ". $WM_PROJECT_DIR/bin/tools/RunFunctions")
+
+    return normalized
+
+
+def _allrun_mesh_plan(
+    dir_structure: Dict[str, List[str]],
+    mesh_type: str,
+    mesh_commands: List[str],
+) -> tuple[bool, List[str], List[str]]:
+    """Classify expected and externally supplied mesh commands."""
+    normalized_mesh_type = (mesh_type or "").strip().lower()
+    external_mesh = normalized_mesh_type in {"custom_mesh", "gmsh_mesh"}
+    expected_mesh_commands: List[str] = []
+    if not external_mesh:
+        for dictionary_name, command in _MESH_DICTIONARY_COMMANDS:
+            if _dir_structure_contains(dir_structure, dictionary_name):
+                expected_mesh_commands.append(command)
+        if normalized_mesh_type in {"blockmesh", "block_mesh"} and "blockMesh" not in expected_mesh_commands:
+            expected_mesh_commands.append("blockMesh")
+    supplied_mesh_commands = [str(command).strip() for command in (mesh_commands or []) if str(command).strip()]
+    supplied_non_checkmesh = [
+        command for command in supplied_mesh_commands
+        if not line_invokes_command(command, "checkMesh") and command != "checkMesh"
+    ]
+    return external_mesh, expected_mesh_commands, supplied_non_checkmesh
+
+
+def _remove_external_mesh_generators(
+    lines: List[str],
+    supplied_commands: List[str],
+) -> List[str]:
+    """Prevent an LLM script from overwriting an already prepared mesh."""
+    allowed_generator_names = {
+        generator
+        for generator in _MESH_GENERATION_COMMANDS
+        if any(line_invokes_command(command, generator) for command in supplied_commands)
+    }
+    return [
+        line
+        for line in lines
+        if not any(
+            line_invokes_command(line, generator) and generator not in allowed_generator_names
+            for generator in _MESH_GENERATION_COMMANDS
+        )
+    ]
+
+
+def _mesh_commands_in_lines(lines: List[str], expected_commands: List[str]) -> List[str]:
+    """Return all mesh generators that must be ordered before checkMesh."""
+    commands = list(expected_commands)
+    for generator in _MESH_GENERATION_COMMANDS:
+        if generator not in commands and any(line_invokes_command(line, generator) for line in lines):
+            commands.append(generator)
+    return commands
+
+
+def _requires_checkmesh(
+    *,
+    external_mesh: bool,
+    expected_commands: List[str],
+    supplied_commands: List[str],
+    had_checkmesh: bool,
+    discovered_commands: List[str],
+) -> bool:
+    return bool(
+        external_mesh
+        or expected_commands
+        or supplied_commands
+        or had_checkmesh
+        or discovered_commands
+    )
+
+
+def _solver_index(lines: List[str], solver: str) -> int:
+    for index, line in enumerate(lines):
+        if line_invokes_solver(line, solver):
+            return index
+    solver_label = solver or "the selected solver"
+    raise ValueError(
+        f"Generated Allrun does not invoke {solver_label}; cannot place checkMesh before the solver."
+    )
+
+
+def _validate_mesh_command_order(
+    lines: List[str],
+    mesh_commands: List[str],
+    solver_index: int,
+    solver: str,
+) -> None:
+    """Reject scripts that run a mesh generator after the selected solver."""
+    for command in mesh_commands:
+        if any(
+            index > solver_index
+            for index, line in enumerate(lines)
+            if line_invokes_command(line, command)
+        ):
+            raise ValueError(
+                f"Generated Allrun invokes mesh command {command} after solver {solver or '<dynamic>'}."
+            )
+
+
+def _missing_mesh_commands(
+    lines: List[str],
+    solver_index: Optional[int],
+    expected_commands: List[str],
+    supplied_commands: List[str],
+    use_run_application: bool,
+) -> List[str]:
+    """Format mesh commands absent from the selected execution scope.
+
+    ``solver_index`` is ``None`` for mesh-only applications such as
+    ``blockMesh``.  In that case the complete script is the scope and the
+    caller appends the missing commands before the final ``checkMesh`` gate.
+    """
+    scope = lines if solver_index is None else lines[:solver_index]
+    commands: List[str] = []
+    for command in expected_commands:
+        if not any(line_invokes_command(line, command) for line in scope):
+            commands.append(_format_allrun_command(command, use_run_application))
+    for command in supplied_commands:
+        command_name = invoked_command(command)
+        if command_name and not any(
+            line_invokes_command(line, command_name) for line in scope
+        ):
+            commands.append(_format_allrun_command(command, use_run_application))
+    return [command for command in commands if command]
+
+
+def _assert_mesh_gate(
+    lines: List[str],
+    solver: str,
+    mesh_commands: List[str],
+) -> None:
+    """Verify the normalizer's mesh -> checkMesh -> solver postcondition."""
+    check_indexes = [
+        index for index, line in enumerate(lines) if line_invokes_command(line, "checkMesh")
+    ]
+    solver_indexes = [
+        index for index, line in enumerate(lines) if line_invokes_solver(line, solver)
+    ]
+    if len(check_indexes) != 1:
+        raise ValueError("Could not enforce exactly one checkMesh gate in generated Allrun.")
+    if solver in _MESH_GENERATION_COMMANDS:
+        if any(
+            index >= check_indexes[0]
+            for index, line in enumerate(lines)
+            for command in mesh_commands
+            if line_invokes_command(line, command)
+        ):
+            raise ValueError("Could not enforce generated mesh command -> checkMesh ordering.")
+        return
+    if not solver_indexes or check_indexes[0] >= solver_indexes[0]:
+        raise ValueError("Could not enforce checkMesh before the solver in generated Allrun.")
+    if any(
+        index >= check_indexes[0]
+        for index, line in enumerate(lines)
+        for command in mesh_commands
+        if line_invokes_command(line, command)
+    ):
+        raise ValueError("Could not enforce generated mesh command -> checkMesh -> solver ordering.")
+
+
+def _ensure_checkmesh_before_solver(
+    allrun_script: str,
+    *,
+    case_info: str,
+    dir_structure: Dict[str, List[str]],
+    mesh_type: str,
+    mesh_commands: List[str],
+) -> str:
+    """Normalize a generated Allrun into mesh -> checkMesh -> solver order."""
+    solver = _extract_case_solver(case_info)
+    lines = _ensure_runfunctions_logging((allrun_script or "").splitlines(), solver)
+    external_mesh, expected_commands, supplied_commands = _allrun_mesh_plan(
+        dir_structure,
+        mesh_type,
+        mesh_commands,
+    )
+
+    # A custom mesh has already been converted by the meshing service. Remove an
+    # LLM-invented generator so it cannot overwrite the uploaded/prepared mesh.
+    if external_mesh:
+        lines = _remove_external_mesh_generators(lines, supplied_commands)
+
+    existing_checkmesh_lines = [
+        line for line in lines if line_invokes_command(line, "checkMesh")
+    ]
+    had_checkmesh = bool(existing_checkmesh_lines)
+    lines = [line for line in lines if not line_invokes_command(line, "checkMesh")]
+
+    discovered_commands = _mesh_commands_in_lines(lines, expected_commands)
+    if not _requires_checkmesh(
+        external_mesh=external_mesh,
+        expected_commands=expected_commands,
+        supplied_commands=supplied_commands,
+        had_checkmesh=had_checkmesh,
+        discovered_commands=discovered_commands,
+    ):
+        return allrun_script
+
+    use_run_application = any(is_run_wrapper(line) for line in lines)
+    if solver in _MESH_GENERATION_COMMANDS:
+        # Mesh tutorials may legitimately declare blockMesh (or another mesh
+        # utility) as ``application``.  That command is the mesh-generation
+        # stage itself, not a solver that must run *after* checkMesh.  Treating
+        # it as both used to duplicate blockMesh and fail the gate assertion.
+        lines.extend(
+            _missing_mesh_commands(
+                lines,
+                None,
+                expected_commands,
+                supplied_commands,
+                use_run_application,
+            )
+        )
+        checkmesh_line = (
+            existing_checkmesh_lines[0].strip()
+            if existing_checkmesh_lines
+            else _format_allrun_command("checkMesh", use_run_application)
+        )
+        lines.append(checkmesh_line)
+        _assert_mesh_gate(
+            lines,
+            solver,
+            _mesh_commands_in_lines(lines, expected_commands),
+        )
+        normalized = "\n".join(lines)
+        if allrun_script.endswith("\n"):
+            normalized += "\n"
+        return normalized
+
+    solver_index = _solver_index(lines, solver)
+    _validate_mesh_command_order(lines, discovered_commands, solver_index, solver)
+    for command in _missing_mesh_commands(
+        lines,
+        solver_index,
+        expected_commands,
+        supplied_commands,
+        use_run_application,
+    ):
+        lines.insert(solver_index, command)
+        solver_index += 1
+
+    checkmesh_line = (
+        existing_checkmesh_lines[0].strip()
+        if existing_checkmesh_lines
+        else _format_allrun_command("checkMesh", use_run_application)
+    )
+    lines.insert(solver_index, checkmesh_line)
+
+    _assert_mesh_gate(lines, solver, discovered_commands)
+
+    normalized = "\n".join(lines)
+    if allrun_script.endswith("\n"):
+        normalized += "\n"
+    return normalized
+
+
+class CommandsPydantic(BaseModel):
+    """Structured command list used to build an Allrun script."""
+
+    commands: List[str] = Field(description="List of commands")
+
+
+def _parse_allrun_response(text: str) -> str:
+    """Extract shell content from an optional Markdown fence."""
+    match = re.search(r"```(.*?)```", text, re.DOTALL)
+    if not match:
+        return text.strip()
+    return re.sub(
+        r"^\s*(?:sh|bash|shell|zsh|ksh)\s*\r?\n",
+        "",
+        match.group(1),
+        count=1,
+        flags=re.IGNORECASE,
+    ).strip()
+
+
+def _read_available_commands(database_path: str) -> str:
+    command_path = os.path.join(database_path, "raw", "openfoam_commands.txt")
+    try:
+        with open(command_path, encoding="utf-8") as command_file:
+            commands = [line.strip() for line in command_file]
+    except OSError as exc:
+        raise ValueError(f"Could not read commands file {command_path}: {exc}") from exc
+    return f"[{', '.join(commands)}]"
+
+
+def _command_help_context(
+    commands: List[str],
+    searchdocs: int,
+    config: Optional[Config],
+) -> str:
+    """Retrieve one concise reference block for each LLM-selected command."""
+    retrieval_kwargs: Dict[str, Any] = {"topk": searchdocs}
+    if config is not None:
+        retrieval_kwargs["config"] = config
+    help_text = [
+        retrieve_faiss("openfoam_command_help", command, **retrieval_kwargs)[0]["full_content"]
+        for command in commands
+    ]
+    return "\n".join(help_text)
+
+
+def _custom_mesh_prompt_info(mesh_type: str, mesh_commands: List[str]) -> str:
+    if mesh_type != "custom_mesh" or not mesh_commands:
+        return ""
+    return f"\nCustom mesh commands to include: {mesh_commands}"
+
+
+def _command_selection_prompts(
+    *,
+    commands: str,
+    dir_structure: Dict[str, List[str]],
+    case_info: str,
+    allrun_reference: str,
+    mesh_type: str,
+    mesh_commands: List[str],
+    user_requirement: str,
+) -> tuple[str, str]:
+    """Build the command-selection prompts for a generated Allrun script."""
+    custom_mesh = mesh_type == "custom_mesh"
+    mesh_commands_info = _custom_mesh_prompt_info(mesh_type, mesh_commands)
+    command_system = (
+        "You are an expert in OpenFOAM. The user will provide a list of available commands. "
+        "Generate only the necessary commands for an Allrun script based on the provided directory structure. "
+        "Return only the command list with no explanation."
+    )
+    if custom_mesh:
+        command_system += " Include custom mesh commands in their appropriate order."
+    command_user = (
+        f"Available OpenFOAM commands for the Allrun script: {commands}\n"
+        f"Case directory structure: {dir_structure}\n"
+        f"User case information: {case_info}\n"
+        f"User requirement: {user_requirement}\n"
+        f"Reference Allrun scripts from similar cases: {allrun_reference}\n"
+        f"{mesh_commands_info}\n"
+        "Generate only the required OpenFOAM command list."
+    )
+    return command_user, command_system
+
+
+def _allrun_script_prompts(
+    *,
+    command_help: str,
+    dir_structure: Dict[str, List[str]],
+    case_info: str,
+    allrun_reference: str,
+    mesh_type: str,
+    mesh_commands: List[str],
+    user_requirement: str,
+) -> tuple[str, str]:
+    """Build the final script prompts after command references are available."""
+    custom_mesh = mesh_type == "custom_mesh"
+    mesh_commands_info = _custom_mesh_prompt_info(mesh_type, mesh_commands)
+    script_system = (
+        "You are an expert in OpenFOAM. Generate an Allrun script based on the provided details."
+        f"Available commands with descriptions: {command_help}\n\n"
+        f"Reference Allrun scripts from similar cases: {allrun_reference}\n\n"
+        "Do not include post-processing commands, mesh conversion commands, or commands that run Gmsh."
+    )
+    script_user = (
+        f"User requirement: {user_requirement}\n"
+        f"Case directory structure: {dir_structure}\n"
+        f"User case information: {case_info}\n"
+        f"{mesh_commands_info}\n"
+        "Reference scripts are informative only; follow the case structure and user requirement. "
+        "Do not include post-processing, mesh conversion, or Gmsh commands. "
+        "Generate only the Allrun script in ``` tags."
+    )
+    if custom_mesh:
+        rule = " Do not include mesh commands other than the supplied custom mesh commands."
+        script_system += rule
+        script_user += rule
+    return script_user, script_system
 
 
 def build_allrun(
@@ -278,6 +865,8 @@ def build_allrun(
     progress_callback: Optional[Callable[[int, int, str], None]] = None,
     progress_offset: int = 0,
     total_steps: int = 0,
+    llm_service: Optional[Any] = None,
+    config: Optional[Config] = None,
 ) -> Dict[str, Any]:
     """
     Build an Allrun script for automated OpenFOAM simulation execution.
@@ -321,120 +910,201 @@ def build_allrun(
         ... )
         >>> print(f"Generated script with {len(result['commands'])} commands")
     """
-    from pydantic import BaseModel, Field
-    from typing import List
-    
-    # Parse allrun helper function
-    def parse_allrun(text: str) -> str:
-        match = re.search(r'```(.*?)```', text, re.DOTALL)
-        return match.group(1).strip() if match else text
-    
-    # CommandsPydantic class for structured response
-    class CommandsPydantic(BaseModel):
-        commands: List[str] = Field(description="List of commands")
-    
-    # Retrieve commands from file
-    command_path = f"{database_path}/raw/openfoam_commands.txt"
-    try:
-        with open(command_path, 'r') as file:
-            commands = file.readlines()
-        commands = f"[{', '.join([c.strip() for c in commands])}]"
-    except (FileNotFoundError, IOError) as e:
-        raise ValueError(f"Could not read commands file {command_path}: {e}")
-
-    # Handle mesh commands info
-    mesh_commands_info = ""
-    if mesh_type == "custom_mesh" and mesh_commands:
-        mesh_commands_info = f"\nCustom mesh commands to include: {mesh_commands}"
-        print(f"Including custom mesh commands: {mesh_commands}")
-
-    # Command generation system prompt
-    command_system_prompt = (
-        "You are an expert in OpenFOAM. The user will provide a list of available commands. "
-        "Your task is to generate only the necessary OpenFOAM commands required to create an Allrun script for the given user case, based on the provided directory structure. "
-        "Return only the list of commands—no explanations, comments, or additional text."
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    commands = _read_available_commands(database_path)
+    command_user_prompt, command_system_prompt = _command_selection_prompts(
+        commands=commands,
+        dir_structure=dir_structure,
+        case_info=case_info,
+        allrun_reference=allrun_reference,
+        mesh_type=mesh_type,
+        mesh_commands=mesh_commands,
+        user_requirement=user_requirement,
+    )
+    command_response = llm_client.invoke(
+        command_user_prompt,
+        command_system_prompt,
+        pydantic_obj=CommandsPydantic,
     )
 
-    if mesh_type == "custom_mesh":
-        command_system_prompt += "If custom mesh commands are provided, include them in the appropriate order (typically after blockMesh or instead of blockMesh if custom mesh is used). "
-    
-    command_user_prompt = (
-        f"Available OpenFOAM commands for the Allrun script: {commands}\n"
-        f"Case directory structure: {dir_structure}\n"
-        f"User case information: {case_info}\n"
-        f"Reference Allrun scripts from similar cases: {allrun_reference}\n"
-        "Generate only the required OpenFOAM command list—no extra text."
+    _report_progress(
+        progress_callback,
+        progress_offset + 1,
+        total_steps,
+        "Generated Allrun commands",
     )
 
-    if mesh_type == "custom_mesh":
-        command_user_prompt += f"{mesh_commands_info}\n"
-    
-    command_response = global_llm_service.invoke(command_user_prompt, command_system_prompt, pydantic_obj=CommandsPydantic)
-
-    if progress_callback:
-        try:
-            progress_callback(progress_offset + 1, total_steps, "Generated Allrun commands")
-        except Exception:
-            pass
-
-    if len(command_response.commands) == 0:
-        print("Failed to generate commands.")
+    if not command_response.commands:
         raise ValueError("Failed to generate commands.")
+    command_help = _command_help_context(command_response.commands, searchdocs, config)
+    allrun_user_prompt, allrun_system_prompt = _allrun_script_prompts(
+        command_help=command_help,
+        dir_structure=dir_structure,
+        case_info=case_info,
+        allrun_reference=allrun_reference,
+        mesh_type=mesh_type,
+        mesh_commands=mesh_commands,
+        user_requirement=user_requirement,
+    )
+    allrun_response = llm_client.invoke(allrun_user_prompt, allrun_system_prompt)
 
-    print(f"Need {len(command_response.commands)} commands.")
-    
-    # Get command help from FAISS
-    commands_help = []
-    for command in command_response.commands:
-        command_help = retrieve_faiss("openfoam_command_help", command, topk=searchdocs)
-        commands_help.append(command_help[0]['full_content'])
-    commands_help = "\n".join(commands_help)
-
-    # Allrun generation system prompt
-    allrun_system_prompt = (
-        "You are an expert in OpenFOAM. Generate an Allrun script based on the provided details."
-        f"Available commands with descriptions: {commands_help}\n\n"
-        f"Reference Allrun scripts from similar cases: {allrun_reference}\n\n"
-        "If custom mesh commands are provided, make sure to include them in the appropriate order in the Allrun script. "
-        "CRITICAL: Do not include any post processing commands in the Allrun script."
-        "CRITICAL: Do not include any commands to convert mesh to foam format like gmshToFoam or others."
+    _report_progress(
+        progress_callback,
+        progress_offset + 2,
+        total_steps,
+        "Generated Allrun script",
     )
 
-    if mesh_type == "custom_mesh":
-        allrun_system_prompt += "CRITICAL: Do not include any other mesh commands other than the custom mesh commands.\n"
-        allrun_system_prompt += "CRITICAL: Do not include any gmshToFoam commands in the Allrun script."
-    
-    allrun_user_prompt = (
-        f"User requirement: {user_requirement}\n"
-        f"Case directory structure: {dir_structure}\n"
-        f"User case infomation: {case_info}\n"
-        f"{mesh_commands_info}\n"
-        "All run scripts for these similar cases are for reference only and may not be correct, as you might be a different case solver or have a different directory structure. " 
-        "You need to rely on your OpenFOAM and physics knowledge to discern this, and pay more attention to user requirements, " 
-        "as your ultimate goal is to fulfill the user's requirements and generate an allrun script that meets those requirements."
-        "CRITICAL: Do not include any post processing commands in the Allrun script."
-        "CRITICAL: Do not include any commands to convert mesh to foam format like gmshToFoam or others."
-        "CRITICAL: Do not include any commands that run gmsh to create the mesh."
-        "Generate the Allrun script strictly based on the above information. Do not include explanations, comments, or additional text. Put the code in ``` tags."
+    allrun_script = _parse_allrun_response(allrun_response)
+    allrun_script = _ensure_checkmesh_before_solver(
+        allrun_script,
+        case_info=case_info,
+        dir_structure=dir_structure,
+        mesh_type=mesh_type,
+        mesh_commands=mesh_commands,
     )
-
-    if mesh_type == "custom_mesh":
-        allrun_user_prompt += "CRITICAL: Do not include any other mesh commands other than the custom mesh commands.\n"
-        allrun_user_prompt += "CRITICAL: Do not include any gmshToFoam commands in the Allrun script."
-
-    allrun_response = global_llm_service.invoke(allrun_user_prompt, allrun_system_prompt)
-
-    if progress_callback:
-        try:
-            progress_callback(progress_offset + 2, total_steps, "Generated Allrun script")
-        except Exception:
-            pass
-
-    allrun_script = parse_allrun(allrun_response)
     allrun_file_path = os.path.join(case_dir, "Allrun")
     save_file(allrun_file_path, allrun_script)
     
-    return {"allrun_path": allrun_file_path, "allrun_script": allrun_script, "commands": command_response.commands}
+    return {
+        "allrun_path": allrun_file_path,
+        "allrun_script": allrun_script,
+        "commands": command_response.commands,
+    }
+
+
+def _load_rewrite_context(
+    case_dir: str,
+    dir_structure: Optional[Dict[str, List[str]]],
+    foamfiles: Optional[Any],
+) -> tuple[Dict[str, List[str]], FoamPydantic]:
+    """Load the current files only when the workflow did not provide them."""
+    if dir_structure is None:
+        print(f"Scanning directory structure from: {case_dir}")
+        dir_structure = scan_case_directory(case_dir)
+    if foamfiles is None:
+        print(f"Reading OpenFOAM files from: {case_dir}")
+        foamfiles = read_case_foamfiles(case_dir, dir_structure)
+    return dir_structure, foamfiles
+
+
+def _rewrite_prompts(
+    *,
+    foamfiles: FoamPydantic,
+    error_logs: List[str],
+    review_analysis: str,
+    rewrite_plan: Optional[Dict[str, Any]],
+    user_requirement: str,
+    openfoam_fork: str,
+    case_solver: str,
+) -> tuple[str, str]:
+    """Build the constrained rewrite request and its compatibility contract."""
+    generation_contract = _generation_contract(openfoam_fork)
+    if rewrite_plan is None:
+        scope_instruction = (
+            "No rewrite plan was supplied. Modify only the files necessary to "
+            "resolve the reported error. "
+        )
+        scope_request = "Update only the files necessary to resolve the reported error."
+    else:
+        scope_instruction = (
+            "Follow rewrite_plan strictly; do not modify files outside "
+            "rewrite_plan.target_files. "
+        )
+        scope_request = "Update only the files listed in rewrite_plan.target_files."
+    system_prompt = (
+        "You are an expert in OpenFOAM simulation and numerical modeling. "
+        "Modify files only to resolve the reported error without changing user-specified parameters. "
+        f"{scope_instruction}"
+        f"The selected solver is {case_solver or 'not specified'}. "
+        "Apply this OpenFOAM compatibility contract to every rewritten file:\n"
+        f"{generation_contract}\n"
+        "Return complete corrected files as JSON: "
+        "list of foamfile: [{file_name, folder_name, content}]."
+    )
+    user_prompt = (
+        f"<foamfiles>{foamfiles}</foamfiles>\n"
+        f"<error_logs>{error_logs}</error_logs>\n"
+        f"<reviewer_analysis>{review_analysis}</reviewer_analysis>\n"
+        f"<rewrite_plan>{rewrite_plan}</rewrite_plan>\n"
+        f"<user_requirement>{user_requirement}</user_requirement>\n"
+        f"<openfoam_fork>{openfoam_fork}</openfoam_fork>\n"
+        f"<case_solver>{case_solver}</case_solver>\n"
+        f"{scope_request}"
+    )
+    return user_prompt, system_prompt
+
+
+def _allowed_rewrite_files(
+    rewrite_plan: Optional[Dict[str, Any]],
+) -> Optional[set[str]]:
+    """Validate supplied review targets while preserving legacy unscoped rewrites.
+
+    The MCP ``apply_fixes`` tool predates rewrite plans and intentionally calls
+    this path with ``None``.  In that case, retain the original behavior of
+    applying all safe paths returned by the LLM.  Graph-driven rewrites that
+    supply a plan remain constrained to its validated target files.
+    """
+    if rewrite_plan is None:
+        return None
+
+    allowed_files: set[str] = set()
+    if isinstance(rewrite_plan, dict):
+        for item in rewrite_plan.get("target_files", []):
+            file_path = item.get("file") if isinstance(item, dict) else None
+            if not file_path:
+                continue
+            try:
+                allowed_files.add(safe_case_relative_from_text(file_path).as_posix())
+            except CasePathSafetyError as exc:
+                raise ValueError(f"Unsafe rewrite target in plan: {file_path!r}") from exc
+    if not allowed_files:
+        raise ValueError("rewrite_plan.target_files must contain at least one safe file path")
+    return allowed_files
+
+
+def _apply_rewrite_response(
+    *,
+    case_dir: str,
+    dir_structure: Dict[str, List[str]],
+    foamfiles: FoamPydantic,
+    response: FoamPydantic,
+    allowed_files: Optional[set[str]],
+) -> tuple[Dict[str, List[str]], FoamPydantic, List[str]]:
+    """Apply safe LLM files, constrained when an allow-list is supplied."""
+    updated_dir = {folder: list(files) for folder, files in dir_structure.items()}
+    by_relative_path = {
+        safe_case_relative_path(item.folder_name, item.file_name).as_posix(): item
+        for item in foamfiles.list_foamfile
+    }
+    updated_files: List[str] = []
+    for foamfile in response.list_foamfile:
+        try:
+            relative = safe_case_relative_path(foamfile.folder_name, foamfile.file_name)
+            file_path = safe_case_path(case_dir, foamfile.folder_name, foamfile.file_name)
+        except CasePathSafetyError as exc:
+            raise ValueError(
+                "LLM returned an unsafe rewrite path: "
+                f"{foamfile.folder_name!r}/{foamfile.file_name!r}"
+            ) from exc
+        relative_path = relative.as_posix()
+        if allowed_files is not None and relative_path not in allowed_files:
+            print(f"Warning: Skipping unplanned rewrite file: {relative_path}")
+            continue
+        folder_name = "" if relative.parent.as_posix() == "." else relative.parent.as_posix()
+        file_name = relative.name
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        save_file(str(file_path), foamfile.content)
+        updated_dir.setdefault(folder_name, [])
+        if file_name not in updated_dir[folder_name]:
+            updated_dir[folder_name].append(file_name)
+        by_relative_path[relative_path] = FoamfilePydantic(
+            file_name=file_name,
+            folder_name=folder_name,
+            content=foamfile.content,
+        )
+        updated_files.append(relative_path)
+    return updated_dir, FoamPydantic(list_foamfile=list(by_relative_path.values())), updated_files
 
 
 
@@ -445,7 +1115,10 @@ def rewrite_files(
     rewrite_plan: Optional[Dict[str, Any]],
     user_requirement: str,
     foamfiles: Optional[Any] = None,
-    dir_structure: Optional[Dict[str, List[str]]] = None
+    dir_structure: Optional[Dict[str, List[str]]] = None,
+    openfoam_fork: str = "foundation",
+    case_solver: str = "",
+    llm_service: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Rewrite OpenFOAM files based on error analysis and reviewer suggestions.
@@ -466,6 +1139,8 @@ def rewrite_files(
                                    If None, will be read from case_dir.
         dir_structure (Optional[Dict[str, List[str]]]): Current directory structure.
                                                         If None, will be scanned from case_dir.
+        openfoam_fork (str, optional): Target OpenFOAM fork. Defaults to "foundation".
+        case_solver (str, optional): Selected solver for compatibility checks.
     
     Returns:
         Dict[str, Any]: Contains:
@@ -488,87 +1163,38 @@ def rewrite_files(
         ... )
         >>> print(f"Updated {len(result['foamfiles'].list_foamfile)} files")
     """
-    # Validate case directory exists
     if not os.path.exists(case_dir):
         raise FileNotFoundError(f"Case directory does not exist: {case_dir}")
-    
-    # Validate review_analysis is provided
     if not review_analysis or review_analysis.strip() == "":
         raise ValueError("review_analysis is required and cannot be empty")
-    
-    # Read directory structure if not provided
-    if dir_structure is None:
-        print(f"Scanning directory structure from: {case_dir}")
-        dir_structure = scan_case_directory(case_dir)
-    
-    # Read foamfiles if not provided
-    if foamfiles is None:
-        print(f"Reading OpenFOAM files from: {case_dir}")
-        foamfiles = read_case_foamfiles(case_dir, dir_structure)
-    
-    from utils import FoamPydantic, FoamfilePydantic  # local import to avoid cycles
-    import re
-
-    rewrite_system_prompt = (
-        "You are an expert in OpenFOAM simulation and numerical modeling. "
-        "Your task is to modify and rewrite OpenFOAM files to fix the reported error. "
-        "Please do not propose solutions that require modifying any parameters declared in the user requirement, try other approaches instead. "
-        "You will receive a rewrite_plan. Follow it strictly: only modify files listed in rewrite_plan.target_files and apply only the requested changes. "
-        "Do not modify files outside the plan. "
-        "Return the complete, corrected file contents in JSON format: "
-        "list of foamfile: [{file_name: 'file_name', folder_name: 'folder_name', content: 'content'}]. "
-        "Ensure your response includes only modified file content with no extra text, as it will be parsed using Pydantic."
+    dir_structure, foamfiles = _load_rewrite_context(case_dir, dir_structure, foamfiles)
+    rewrite_user_prompt, rewrite_system_prompt = _rewrite_prompts(
+        foamfiles=foamfiles,
+        error_logs=error_logs,
+        review_analysis=review_analysis,
+        rewrite_plan=rewrite_plan,
+        user_requirement=user_requirement,
+        openfoam_fork=openfoam_fork,
+        case_solver=case_solver,
+    )
+    allowed_files = _allowed_rewrite_files(rewrite_plan)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    response = llm_client.invoke(
+        rewrite_user_prompt,
+        rewrite_system_prompt,
+        pydantic_obj=FoamPydantic,
     )
 
-    rewrite_user_prompt = (
-        f"<foamfiles>{str(foamfiles)}</foamfiles>\n"
-        f"<error_logs>{error_logs}</error_logs>\n"
-        f"<reviewer_analysis>{review_analysis}</reviewer_analysis>\n"
-        f"<rewrite_plan>{rewrite_plan}</rewrite_plan>\n\n"
-        f"<user_requirement>{user_requirement}</user_requirement>\n\n"
-        "Please update OpenFOAM files according to rewrite_plan only. "
-        "Only include files from rewrite_plan.target_files in your output."
+    updated_dir, updated_foamfiles, updated_files = _apply_rewrite_response(
+        case_dir=case_dir,
+        dir_structure=dir_structure,
+        foamfiles=foamfiles,
+        response=response,
+        allowed_files=allowed_files,
     )
-
-    response = global_llm_service.invoke(rewrite_user_prompt, rewrite_system_prompt, pydantic_obj=FoamPydantic)
-
-    allowed_files = set()
-    if rewrite_plan and isinstance(rewrite_plan, dict):
-        for item in rewrite_plan.get("target_files", []):
-            file_path = item.get("file") if isinstance(item, dict) else None
-            if file_path:
-                allowed_files.add(file_path.strip().lstrip("./"))
-
-    # Prepare updated structures
-    updated_dir = dict(dir_structure) if dir_structure else {}
-    foamfiles_list = []
-    if foamfiles and hasattr(foamfiles, "list_foamfile") and foamfiles.list_foamfile:
-        foamfiles_list = list(foamfiles.list_foamfile)
-
-    for foamfile in response.list_foamfile:
-        rel_path = os.path.join(foamfile.folder_name, foamfile.file_name).replace('\\', '/').lstrip('./')
-        if allowed_files and rel_path not in allowed_files:
-            print(f"Warning: Skipping unplanned rewrite file: {rel_path}")
-            continue
-
-        file_path = os.path.join(case_dir, foamfile.folder_name, foamfile.file_name)
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
-        save_file(file_path, foamfile.content)
-
-        if foamfile.folder_name not in updated_dir:
-            updated_dir[foamfile.folder_name] = []
-        if foamfile.file_name not in updated_dir[foamfile.folder_name]:
-            updated_dir[foamfile.folder_name].append(foamfile.file_name)
-
-        foamfiles_list = [
-            f for f in foamfiles_list
-            if not (f.folder_name == foamfile.folder_name and f.file_name == foamfile.file_name)
-        ]
-        foamfiles_list.append(foamfile)
-
-    updated_foamfiles = FoamPydantic(list_foamfile=foamfiles_list)
     return {
         "dir_structure": updated_dir,
         "foamfiles": updated_foamfiles,
         "error_logs": [],
+        "updated_files": updated_files,
     }

--- a/src/services/mesh.py
+++ b/src/services/mesh.py
@@ -2,13 +2,56 @@ import os
 import re
 import shutil
 import subprocess
-from typing import Dict, List, Tuple, Any
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple, Any, Optional
 from pydantic import BaseModel, Field
 from utils import save_file
 from . import global_llm_service
 
 
-def copy_custom_mesh(custom_mesh_path: str, user_requirement: str, case_dir: str) -> Dict[str, Any]:
+_MESH_COMMAND_TIMEOUT_SECONDS = 300
+
+
+def _mesh_failure(error_logs: List[str]) -> Dict[str, Any]:
+    """Return the complete, stable payload for an unsuccessful mesh attempt."""
+    return {
+        "mesh_info": None,
+        "mesh_commands": [],
+        "mesh_file_destination": None,
+        "custom_mesh_used": False,
+        "error_logs": error_logs,
+    }
+
+
+def _mesh_success(
+    mesh_path: str,
+    description: str,
+    *,
+    mesh_commands: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Return the complete, stable payload for a prepared Gmsh mesh."""
+    return {
+        "mesh_info": {
+            "mesh_file_path": mesh_path,
+            "mesh_file_type": "gmsh",
+            "mesh_description": description,
+            "requires_blockmesh_removal": True,
+        },
+        "mesh_commands": mesh_commands or [],
+        "mesh_file_destination": mesh_path,
+        "custom_mesh_used": True,
+        "error_logs": [],
+    }
+
+
+def copy_custom_mesh(
+    custom_mesh_path: str,
+    user_requirement: str,
+    case_dir: str,
+    *,
+    llm_service: Optional[Any] = None,
+) -> Dict[str, Any]:
     """
     Copy and process a custom mesh file for OpenFOAM simulation.
     
@@ -45,14 +88,17 @@ def copy_custom_mesh(custom_mesh_path: str, user_requirement: str, case_dir: str
         ... )
         >>> print(f"Mesh processed: {result['mesh_info']['mesh_file_path']}")
     """
-    error_logs: List[str] = []
     if not custom_mesh_path:
-        return {"mesh_info": None, "mesh_commands": [], "error_logs": ["No custom mesh path provided"]}
+        return _mesh_failure(["No custom mesh path provided"])
     if not os.path.exists(custom_mesh_path):
-        return {"mesh_info": None, "mesh_commands": [], "error_logs": [f"Custom mesh not found: {custom_mesh_path}"]}
+        return _mesh_failure([f"Custom mesh not found: {custom_mesh_path}"])
 
+    os.makedirs(case_dir, exist_ok=True)
     mesh_in_case_dir = os.path.join(case_dir, "geometry.msh")
-    shutil.copy2(custom_mesh_path, mesh_in_case_dir)
+    try:
+        shutil.copy2(custom_mesh_path, mesh_in_case_dir)
+    except OSError as exc:
+        return _mesh_failure([f"Could not copy custom mesh: {exc}"])
 
     constant_dir = os.path.join(case_dir, "constant")
     system_dir = os.path.join(case_dir, "system")
@@ -65,8 +111,8 @@ def copy_custom_mesh(custom_mesh_path: str, user_requirement: str, case_dir: str
         "The file should include only the essential settings needed for gmshToFoam to work. "
         "IMPORTANT: Return ONLY the complete controlDict file content without any additional text."
     )
-    # Use global llm instance
-    controldict_content = global_llm_service.invoke(controldict_prompt, (
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    controldict_content = llm_client.invoke(controldict_prompt, (
         "You are an expert in OpenFOAM simulation setup. "
         "Create a minimal controlDict for gmshToFoam."
     )).strip()
@@ -75,29 +121,35 @@ def copy_custom_mesh(custom_mesh_path: str, user_requirement: str, case_dir: str
 
     # Convert mesh
     try:
-        result = subprocess.run(["gmshToFoam", "geometry.msh"], cwd=case_dir, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        subprocess.run(
+            ["gmshToFoam", "geometry.msh"],
+            cwd=case_dir,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_MESH_COMMAND_TIMEOUT_SECONDS,
+        )
     except subprocess.CalledProcessError as e:
-        return {"mesh_info": None, "mesh_commands": [], "error_logs": [f"gmshToFoam failed: {e.stderr}"]}
+        return _mesh_failure([f"gmshToFoam failed: {e.stderr or e.stdout or e}"])
+    except OSError as exc:
+        return _mesh_failure([f"Could not start gmshToFoam: {exc}"])
+    except subprocess.TimeoutExpired:
+        return _mesh_failure([
+            f"gmshToFoam timed out after {_MESH_COMMAND_TIMEOUT_SECONDS}s"
+        ])
 
     polyMesh_dir = os.path.join(constant_dir, "polyMesh")
     if not os.path.exists(polyMesh_dir):
-        return {"mesh_info": None, "mesh_commands": [], "error_logs": ["polyMesh directory not created"]}
+        return _mesh_failure(["gmshToFoam completed but constant/polyMesh was not created"])
 
     foam_file = os.path.join(case_dir, f"{os.path.basename(case_dir)}.foam")
-    with open(foam_file, 'w') as f:
-        pass
-
-    return {
-        "mesh_info": {
-            "mesh_file_path": mesh_in_case_dir,
-            "mesh_file_type": "gmsh",
-            "mesh_description": "Custom mesh processed by preprocessor",
-            "requires_blockmesh_removal": True,
-        },
-        "mesh_commands": ["checkMesh"],
-        "custom_mesh_used": True,
-        "error_logs": error_logs,
-    }
+    Path(foam_file).touch()
+    return _mesh_success(
+        mesh_in_case_dir,
+        "Custom mesh processed by preprocessor",
+        mesh_commands=["checkMesh"],
+    )
 
 
 def prepare_standard_mesh(user_requirement: str, case_dir: str) -> Dict[str, Any]:
@@ -268,7 +320,20 @@ class GMSHPythonCorrection(BaseModel):
     error_analysis: str = Field(description="Analysis of the error and what was fixed")
 
 
-def extract_boundary_names_from_requirements(user_requirement: str) -> List[str]:
+def _keyword_boundary_names(user_requirement: str) -> List[str]:
+    """Provide a deterministic fallback when boundary-name extraction is unavailable."""
+    requirement_lower = (user_requirement or "").lower()
+    boundary_keywords = [
+        "inlet", "outlet", "wall", "cylinder", "top", "bottom", "front", "back", "side",
+    ]
+    return [keyword for keyword in boundary_keywords if keyword in requirement_lower]
+
+
+def extract_boundary_names_from_requirements(
+    user_requirement: str,
+    *,
+    llm_service: Optional[Any] = None,
+) -> List[str]:
     try:
         extraction_prompt = (
             f"<user_requirements>{user_requirement}</user_requirements>\n"
@@ -277,22 +342,21 @@ def extract_boundary_names_from_requirements(user_requirement: str) -> List[str]
             "Focus on boundaries that would need to be defined in the mesh for OpenFOAM simulation. "
             "Return ONLY a comma-separated list of boundary names without any additional text."
         )
-        boundary_response = global_llm_service.invoke(extraction_prompt, BOUNDARY_EXTRACTION_SYSTEM_PROMPT).strip()
+        llm_client = llm_service if llm_service is not None else global_llm_service
+        boundary_response = llm_client.invoke(extraction_prompt, BOUNDARY_EXTRACTION_SYSTEM_PROMPT).strip()
         if boundary_response:
             return [name.strip() for name in boundary_response.split(',') if name.strip()]
         return []
-    except Exception:
-        # Fallback keyword search
-        requirement_lower = (user_requirement or "").lower()
-        boundary_keywords = ['inlet', 'outlet', 'wall', 'cylinder', 'top', 'bottom', 'front', 'back', 'side']
-        return [k for k in boundary_keywords if k in requirement_lower]
+    except Exception as exc:  # noqa: BLE001 - LLM provider exceptions are implementation-specific
+        print(f"Boundary extraction failed; using keyword fallback: {exc}")
+        return _keyword_boundary_names(user_requirement)
 
 
 def check_boundary_file_for_missing_boundaries(boundary_file_path: str, expected_boundaries: List[str]):
     if not os.path.exists(boundary_file_path):
         return False, expected_boundaries, []
     try:
-        with open(boundary_file_path, 'r') as f:
+        with open(boundary_file_path, encoding="utf-8") as f:
             content = f.read()
         boundary_pattern = r'(\w+)\s*\{'
         found_boundaries = re.findall(boundary_pattern, content)
@@ -300,11 +364,19 @@ def check_boundary_file_for_missing_boundaries(boundary_file_path: str, expected
         found_boundaries = [b for b in found_boundaries if b not in boundary_keywords]
         missing_boundaries = [b for b in expected_boundaries if b not in found_boundaries]
         return len(missing_boundaries) == 0, missing_boundaries, found_boundaries
-    except Exception:
+    except (OSError, UnicodeError):
         return False, expected_boundaries, []
 
 
-def _correct_gmsh_python_code(user_requirement: str, current_code: str, error_output: str, found_boundaries=None, expected_boundaries=None):
+def _correct_gmsh_python_code(
+    user_requirement: str,
+    current_code: str,
+    error_output: str,
+    found_boundaries=None,
+    expected_boundaries=None,
+    *,
+    llm_service: Optional[Any] = None,
+):
     try:
         is_boundary_mismatch = isinstance(error_output, str) and "Boundary mismatch after gmshToFoam" in error_output
         boundary_info = ""
@@ -312,7 +384,8 @@ def _correct_gmsh_python_code(user_requirement: str, current_code: str, error_ou
             boundary_info = (
                 f"\n<boundary_mismatch>Found boundaries in OpenFOAM: {found_boundaries}. "
                 f"Expected boundaries: {expected_boundaries}. "
-                "Please correct the mesh code so that the boundaries in the OpenFOAM boundary file match the expected boundaries exactly."
+                "Please correct the mesh code so that every requested boundary is present in the OpenFOAM boundary file. "
+                "Additional valid boundaries may remain present."
                 "Note that these boundaries might be present in the msh file, but not in the boundary file after running gmshToFoam to convert the msh file to OpenFOAM format."
                 "MOST LIKELY CAUSES: "
                 "1. Physical groups were created before mesh generation. Move ALL physical group creation to AFTER gmsh.model.mesh.generate(3). "
@@ -327,13 +400,13 @@ def _correct_gmsh_python_code(user_requirement: str, current_code: str, error_ou
                 f"<user_requirements>{user_requirement}</user_requirements>{boundary_info}\n"
                 f"<current_python_code>{current_code}</current_python_code>\n"
                 "Please analyze the current Python code and the boundary mismatch information. "
-                "The mesh generation was successful, but the boundaries in the OpenFOAM conversion do not match the expected boundaries. "
+                "The mesh generation was successful, but one or more requested boundaries are missing after OpenFOAM conversion. "
                 "MOST LIKELY SOLUTIONS: "
                 "1. Move ALL physical group creation to AFTER gmsh.model.mesh.generate(3). "
                 "2. Use correct thin boundary detection: abs(zmin - zmax) < tol AND (abs(zmin - z_min) < tol OR abs(zmin - z_max) < tol). "
                 "3. Use tolerance tol = 1e-6 for all floating point comparisons. "
                 "4. Use exact boundary names from user requirements, do not hardcode specific names. "
-                "Provide a corrected Python code that ensures the boundaries in the OpenFOAM boundary file match the expected boundaries exactly. "
+                "Provide a corrected Python code that ensures every requested boundary exists in the OpenFOAM boundary file. "
                 "IMPORTANT: Return ONLY the complete corrected Python code without any additional text."
             )
         else:
@@ -345,22 +418,39 @@ def _correct_gmsh_python_code(user_requirement: str, current_code: str, error_ou
                 "Identify the specific error and provide a corrected Python code that fixes the issue. "
                 "IMPORTANT: Return ONLY the complete corrected Python code without any additional text."
             )
-        correction_response = global_llm_service.invoke(
+        llm_client = llm_service if llm_service is not None else global_llm_service
+        correction_response = llm_client.invoke(
             correction_prompt,
             GMSH_PYTHON_ERROR_CORRECTION_SYSTEM_PROMPT,
             pydantic_obj=GMSHPythonCorrection,
         )
         if correction_response.corrected_code:
             return correction_response.corrected_code
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001 - LLM provider exceptions are implementation-specific
+        print(f"Gmsh correction request failed: {exc}")
     return None
 
 
-def run_checkmesh_and_correct(case_dir: str, python_file: str, max_loop: int, current_loop: int) -> Tuple[bool, bool, str]:
+def run_checkmesh_and_correct(
+    case_dir: str,
+    python_file: str,
+    user_requirement: str,
+    max_loop: int,
+    current_loop: int,
+    *,
+    llm_service: Optional[Any] = None,
+) -> Tuple[bool, bool, str]:
     """Run checkMesh and optionally generate corrected code. Returns (success, should_continue, corrected_code)."""
     try:
-        result = subprocess.run(["checkMesh"], cwd=case_dir, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(
+            ["checkMesh"],
+            cwd=case_dir,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_MESH_COMMAND_TIMEOUT_SECONDS,
+        )
         checkmesh_output = result.stdout
         if "Failed" in checkmesh_output and "mesh checks" in checkmesh_output:
             failed_match = re.search(r"Failed (\d+) mesh checks", checkmesh_output)
@@ -372,23 +462,183 @@ def run_checkmesh_and_correct(case_dir: str, python_file: str, max_loop: int, cu
                     "Please analyze the checkMesh output and correct the mesh generation code. "
                     "Common issues include poor mesh quality, geometry issues, boundary layer problems, and boundary naming mismatch."
                 )
-                corrected_code = _correct_gmsh_python_code("", current_code, checkmesh_error)
+                corrected_code = _correct_gmsh_python_code(
+                    user_requirement,
+                    current_code,
+                    checkmesh_error,
+                    llm_service=llm_service,
+                )
                 if corrected_code:
                     return False, True, corrected_code
             return False, False, ""
         return True, False, ""
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         if current_loop < max_loop:
-            return False, True, ""
+            return False, True, None
         return False, False, ""
-    except Exception:
+    except OSError:
         return False, False, ""
+    except subprocess.TimeoutExpired:
+        return False, False, ""
+
+
+def _next_gmsh_code(
+    user_requirement: str,
+    llm_client: Any,
+    corrected_python_code: Optional[str],
+) -> tuple[str, str]:
+    """Use a correction when available, otherwise request a fresh Gmsh script."""
+    if corrected_python_code is not None:
+        return corrected_python_code, "corrected"
+    python_prompt = (
+        f"<user_requirements>{user_requirement}</user_requirements>\n"
+        "Please create Python code using the GMSH library to generate a mesh based on the user requirements. "
+        "Use boundary names specified in user requirements (for example inlet, outlet, wall, or cylinder). "
+        "Return ONLY the complete Python code without any additional text."
+    )
+    response = llm_client.invoke(
+        python_prompt,
+        GMSH_PYTHON_SYSTEM_PROMPT,
+        pydantic_obj=GMSHPythonCode,
+    )
+    return response.python_code, response.geometry_type
+
+
+def _run_gmsh_python(case_dir: str, python_file: str, python_code: str) -> str:
+    """Write and execute generated Gmsh code, returning its diagnostic output."""
+    save_file(python_file, python_code)
+    process = subprocess.run(
+        [sys.executable, python_file],
+        cwd=case_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=_MESH_COMMAND_TIMEOUT_SECONDS,
+    )
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(
+            process.returncode,
+            process.args,
+            output=process.stdout,
+            stderr=process.stderr,
+        )
+    return process.stderr
+
+
+def _convert_gmsh_mesh(
+    case_dir: str,
+    user_requirement: str,
+    llm_client: Any,
+) -> str:
+    """Generate conversion support files and return the resulting boundary path."""
+    constant_dir = os.path.join(case_dir, "constant")
+    system_dir = os.path.join(case_dir, "system")
+    os.makedirs(constant_dir, exist_ok=True)
+    os.makedirs(system_dir, exist_ok=True)
+    control_prompt = (
+        f"<user_requirements>{user_requirement}</user_requirements>\n"
+        "Create a minimal controlDict needed for gmshToFoam. Return ONLY the complete controlDict content."
+    )
+    control_dict = llm_client.invoke(control_prompt, CONTROLDICT_SYSTEM_PROMPT).strip()
+    if control_dict:
+        save_file(os.path.join(system_dir, "controlDict"), control_dict)
+    subprocess.run(
+        ["gmshToFoam", "geometry.msh"],
+        cwd=case_dir,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=_MESH_COMMAND_TIMEOUT_SECONDS,
+    )
+    boundary_file = os.path.join(constant_dir, "polyMesh", "boundary")
+    if not os.path.isfile(boundary_file):
+        raise FileNotFoundError("gmshToFoam completed without creating polyMesh/boundary")
+    return boundary_file
+
+
+def _correct_boundary_mismatch(
+    boundary_file: str,
+    expected_boundaries: List[str],
+    *,
+    user_requirement: str,
+    python_code: str,
+    llm_client: Any,
+) -> tuple[bool, Optional[str]]:
+    """Report a mismatch and optionally provide an LLM-generated correction."""
+    if not expected_boundaries:
+        return False, None
+    has_expected_boundaries, missing_boundaries, found_boundaries = check_boundary_file_for_missing_boundaries(
+        boundary_file,
+        expected_boundaries,
+    )
+    if has_expected_boundaries:
+        return False, None
+    mismatch = (
+        "Boundary mismatch after gmshToFoam. "
+        f"Found boundaries: {found_boundaries}. "
+        f"Missing requested boundaries: {missing_boundaries}."
+    )
+    return (
+        True,
+        _correct_gmsh_python_code(
+            user_requirement,
+            python_code,
+            mismatch,
+            found_boundaries,
+            expected_boundaries,
+            llm_service=llm_client,
+        ),
+    )
+
+
+def _clear_gmsh_attempt_outputs(case_dir: str) -> None:
+    """Remove only artifacts regenerated by the next Gmsh attempt.
+
+    A failed script can leave a valid-looking ``geometry.msh`` or ``polyMesh``.
+    Keeping either would let a later failed retry convert or validate stale data.
+    """
+    msh_file = Path(case_dir) / "geometry.msh"
+    if msh_file.is_symlink() or msh_file.is_file():
+        msh_file.unlink()
+    elif msh_file.exists():
+        raise OSError(f"Expected mesh artifact is not a regular file: {msh_file}")
+
+    poly_mesh = Path(case_dir) / "constant" / "polyMesh"
+    if poly_mesh.is_symlink():
+        poly_mesh.unlink()
+    elif poly_mesh.exists():
+        if not poly_mesh.is_dir():
+            raise OSError(f"Expected polyMesh artifact is not a directory: {poly_mesh}")
+        shutil.rmtree(poly_mesh)
+
+
+def _update_boundary_file(
+    boundary_file: str,
+    user_requirement: str,
+    llm_client: Any,
+) -> None:
+    """Apply only the requested boundary-type changes after mesh validation."""
+    with open(boundary_file, encoding="utf-8") as boundary_source:
+        boundary_content = boundary_source.read()
+    boundary_prompt = (
+        f"<user_requirements>{user_requirement}</user_requirements>\n"
+        f"<boundary_file_content>{boundary_content}</boundary_file_content>\n"
+        "Update only the boundary types required by the user. For 2D cases, use empty only for the appropriate front/back boundary. "
+        "For no-slip boundaries, use wall. Leave all other boundaries unchanged. "
+        "Return ONLY the complete boundary file content."
+    )
+    updated_boundary = llm_client.invoke(boundary_prompt, BOUNDARY_SYSTEM_PROMPT).strip()
+    if updated_boundary:
+        save_file(boundary_file, updated_boundary)
 
 
 def handle_gmsh_mesh(
     user_requirement: str,
     case_dir: str,
-    max_loop: int = 3
+    max_loop: int = 3,
+    *,
+    llm_service: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Generate GMSH mesh for OpenFOAM simulation using Python API.
@@ -428,166 +678,100 @@ def handle_gmsh_mesh(
         >>> print(f"Mesh generated: {result['mesh_info']['mesh_file_path']}")
     """
     case_dir = os.path.abspath(case_dir)
+    attempts = max(1, max_loop)
     error_logs: List[str] = []
-    if os.path.exists(case_dir):
-        shutil.rmtree(case_dir)
-    os.makedirs(case_dir)
-
+    # Planner owns the case directory and may already have written references,
+    # logs, and the output ownership marker.  Mesh generation only adds assets.
+    os.makedirs(case_dir, exist_ok=True)
+    llm_client = llm_service if llm_service is not None else global_llm_service
     python_file = os.path.join(case_dir, "generate_mesh.py")
     msh_file = os.path.join(case_dir, "geometry.msh")
+    expected_boundaries = extract_boundary_names_from_requirements(
+        user_requirement,
+        llm_service=llm_client,
+    )
+    corrected_python_code: Optional[str] = None
+    python_code = ""
 
-    expected_boundaries = extract_boundary_names_from_requirements(user_requirement)
-
-    gmsh_python_current_loop = 0
-    corrected_python_code = None
-
-    while gmsh_python_current_loop < max_loop:
-        gmsh_python_current_loop += 1
-        should_generate_new_code = corrected_python_code is None
+    for attempt in range(1, attempts + 1):
         try:
-            if should_generate_new_code:
-                missing_boundary_info = ""
-                python_prompt = (
-                    f"<user_requirements>{user_requirement}</user_requirements>\n"
-                    f"{missing_boundary_info}"
-                    "Please create Python code using the GMSH library to generate a mesh based on the user requirements. "
-                    "Use boundary names specified in user requirements (e.g., 'inlet', 'outlet', 'wall', 'cylinder', etc.). "
-                    "Return ONLY the complete Python code without any additional text."
-                )
-                python_response = global_llm_service.invoke(python_prompt, GMSH_PYTHON_SYSTEM_PROMPT, pydantic_obj=GMSHPythonCode)  # type: ignore
-                if not python_response.python_code:
-                    if gmsh_python_current_loop >= max_loop:
-                        return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
-                    continue
-                python_code_to_use = python_response.python_code
-                geometry_type = python_response.geometry_type
-            else:
-                python_code_to_use = corrected_python_code
-                geometry_type = "corrected"
-
-            save_file(python_file, python_code_to_use)
+            _clear_gmsh_attempt_outputs(case_dir)
+            python_code, geometry_type = _next_gmsh_code(
+                user_requirement,
+                llm_client,
+                corrected_python_code,
+            )
             corrected_python_code = None
-
-            process = subprocess.Popen(["python", python_file], cwd=case_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1, universal_newlines=True)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            return_code = process.wait()
-            stderr_output = process.stderr.read()
-            if return_code != 0:
-                raise subprocess.CalledProcessError(return_code, process.args, stderr=stderr_output)
-
-            if not os.path.exists(msh_file):
-                if stderr_output and gmsh_python_current_loop < max_loop:
-                    corrected = _correct_gmsh_python_code(user_requirement, python_code_to_use, stderr_output)
-                    if corrected:
-                        corrected_python_code = corrected
-                        continue
-                if gmsh_python_current_loop >= max_loop:
-                    return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
+            if not python_code:
+                error_logs.append("Gmsh code generation returned an empty script.")
+                continue
+            stderr_output = _run_gmsh_python(case_dir, python_file, python_code)
+            if not os.path.isfile(msh_file):
+                error_logs.append("Gmsh script completed without creating geometry.msh.")
+                corrected_python_code = _correct_gmsh_python_code(
+                    user_requirement,
+                    python_code,
+                    stderr_output or error_logs[-1],
+                    llm_service=llm_client,
+                )
+                continue
+            boundary_file = _convert_gmsh_mesh(case_dir, user_requirement, llm_client)
+            has_mismatch, corrected_python_code = _correct_boundary_mismatch(
+                boundary_file,
+                expected_boundaries,
+                user_requirement=user_requirement,
+                python_code=python_code,
+                llm_client=llm_client,
+            )
+            if has_mismatch:
+                error_logs.append("Boundary names generated by Gmsh do not match the requested boundaries.")
                 continue
 
-            # Preprocess for OpenFOAM conversion
-            constant_dir = os.path.join(case_dir, "constant")
-            system_dir = os.path.join(case_dir, "system")
-            os.makedirs(constant_dir, exist_ok=True)
-            os.makedirs(system_dir, exist_ok=True)
-            controldict_prompt = (
-                f"<user_requirements>{user_requirement}</user_requirements>\n"
-                "Please create a basic controlDict file for mesh conversion. "
-                "The file should include only the essential settings needed for gmshToFoam to work. "
-                "IMPORTANT: Return ONLY the complete controlDict file content without any additional text."
+            mesh_ok, should_retry, corrected_python_code = run_checkmesh_and_correct(
+                case_dir,
+                python_file,
+                user_requirement,
+                attempts,
+                attempt,
+                llm_service=llm_client,
             )
-            controldict_content = global_llm_service.invoke(controldict_prompt, CONTROLDICT_SYSTEM_PROMPT).strip()  # type: ignore
-            if controldict_content:
-                save_file(os.path.join(system_dir, "controlDict"), controldict_content)
+            if not mesh_ok:
+                error_logs.append("checkMesh did not pass for the generated mesh.")
+                if should_retry:
+                    continue
+                return _mesh_failure(error_logs)
+            _update_boundary_file(boundary_file, user_requirement, llm_client)
+            # The boundary update is LLM-produced. Validate the final mesh, not
+            # merely the version that existed before the update.
+            mesh_ok, should_retry, corrected_python_code = run_checkmesh_and_correct(
+                case_dir,
+                python_file,
+                user_requirement,
+                attempts,
+                attempt,
+                llm_service=llm_client,
+            )
+            if not mesh_ok:
+                error_logs.append("checkMesh did not pass after the boundary update.")
+                if should_retry:
+                    continue
+                return _mesh_failure(error_logs)
+            Path(case_dir, f"{os.path.basename(case_dir)}.foam").touch()
+            return _mesh_success(msh_file, f"GMSH generated {geometry_type} mesh")
+        except subprocess.CalledProcessError as exc:
+            details = exc.stderr or exc.stdout or str(exc)
+            error_logs.append(f"Mesh command failed: {details}")
+            corrected_python_code = _correct_gmsh_python_code(
+                user_requirement,
+                python_code,
+                str(details),
+                llm_service=llm_client,
+            )
+        except subprocess.TimeoutExpired:
+            error_logs.append(
+                f"Mesh command timed out after {_MESH_COMMAND_TIMEOUT_SECONDS}s."
+            )
+        except OSError as exc:
+            error_logs.append(f"Mesh setup failed: {exc}")
 
-            result = subprocess.run(["gmshToFoam", "geometry.msh"], cwd=case_dir, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            polyMesh_dir = os.path.join(constant_dir, "polyMesh")
-            if not os.path.exists(polyMesh_dir):
-                raise subprocess.CalledProcessError(1, "gmshToFoam", "polyMesh directory not created")
-
-            boundary_file = os.path.join(polyMesh_dir, "boundary")
-            if os.path.exists(boundary_file):
-                all_present, missing_boundaries, found_boundaries = check_boundary_file_for_missing_boundaries(boundary_file, expected_boundaries)
-                if set(found_boundaries) != set(expected_boundaries):
-                    if gmsh_python_current_loop < max_loop:
-                        with open(python_file, 'r') as f:
-                            current_code = f.read()
-                        boundary_error = (
-                            f"Boundary mismatch after gmshToFoam. Found boundaries: {found_boundaries}. Expected boundaries: {expected_boundaries}. "
-                        )
-                        corrected = _correct_gmsh_python_code(user_requirement, current_code, boundary_error, found_boundaries, expected_boundaries)
-                        if corrected:
-                            corrected_python_code = corrected
-                            continue
-                    else:
-                        return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
-
-                # Mesh quality check and possible correction
-                ok, should_continue, corrected = run_checkmesh_and_correct(case_dir, python_file, max_loop, gmsh_python_current_loop)  # type: ignore
-                if not ok:
-                    if should_continue and corrected:
-                        corrected_python_code = corrected
-                        continue
-                    if should_continue:
-                        continue
-                    return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
-
-                # Boundary update as per requirements
-                with open(boundary_file, 'r') as f:
-                    boundary_content = f.read()
-                boundary_prompt = (
-                    f"<user_requirements>{user_requirement}</user_requirements>\n"
-                    f"<boundary_file_content>{boundary_content}</boundary_file_content>\n"
-                    "Please analyze the user requirements and boundary file content. "
-                    "Identify which boundary is to be modified based on the boundaries mentioned in the user requirements."
-                    "If this is a 2D simulation, modify ONLY the appropriate boundary to 'empty' type and 'empty' physicalType. "
-                    "Based on the no slip boundaries mentioned in the user requirements, modify the appropriate boundary/boundaries to type 'wall' and physicalType 'wall'. "
-                    "If this is a 3D simulation, only modify the appropriate boundary/boundaries to type 'wall' and physicalType 'wall'."
-                    "IMPORTANT: Do not change any other boundaries - leave them exactly as they are. "
-                    "Return ONLY the complete boundary file content with any necessary modifications. No additional text."
-                )
-                updated_boundary_content = global_llm_service.invoke(boundary_prompt, BOUNDARY_SYSTEM_PROMPT).strip()  # type: ignore
-                if updated_boundary_content:
-                    save_file(boundary_file, updated_boundary_content)
-
-            # Create .foam file and return info
-            foam_file = os.path.join(case_dir, f"{os.path.basename(case_dir)}.foam")
-            with open(foam_file, 'w'):
-                pass
-
-            mesh_commands: List[str] = []
-            return {
-                "mesh_info": {
-                    "mesh_file_path": msh_file,
-                    "mesh_file_type": "gmsh",
-                    "mesh_description": f"GMSH generated {geometry_type} mesh",
-                    "requires_blockmesh_removal": True,
-                },
-                "mesh_commands": mesh_commands,
-                "mesh_file_destination": msh_file,
-                "custom_mesh_used": True,
-                "error_logs": error_logs,
-            }
-        except subprocess.CalledProcessError as e:
-            if gmsh_python_current_loop < max_loop:
-                try:
-                    with open(python_file, 'r') as f:
-                        current_code = f.read()
-                    corrected = _correct_gmsh_python_code(user_requirement, current_code, e.stderr)
-                    if corrected:
-                        corrected_python_code = corrected
-                        continue
-                except Exception:
-                    pass
-            if gmsh_python_current_loop >= max_loop:
-                return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
-        except Exception:
-            if gmsh_python_current_loop >= max_loop:
-                return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
-            continue
-
-    return {"mesh_info": None, "mesh_commands": [], "mesh_file_destination": None, "error_logs": error_logs}
-
+    return _mesh_failure(error_logs or [f"Mesh generation failed after {attempts} attempts."])

--- a/src/services/openfoam_commands.py
+++ b/src/services/openfoam_commands.py
@@ -1,0 +1,39 @@
+"""Command policy shared by OpenFOAM generation, import, and execution.
+
+The list intentionally describes commands that can create or mutate a mesh.
+Every such command must be followed by ``checkMesh`` before a flow solver is
+allowed to start.
+"""
+
+from __future__ import annotations
+
+
+MESH_MUTATING_COMMANDS = frozenset(
+    {
+        "autoPatch",
+        "blockMesh",
+        "cartesianMesh",
+        "cfx4ToFoam",
+        "createBaffles",
+        "createNonConformalCouples",
+        "createPatch",
+        "extrudeMesh",
+        "fluentMeshToFoam",
+        "foamyMesh",
+        "gmshToFoam",
+        "ideasUnvToFoam",
+        "mergeMeshes",
+        "netgenNeutralToFoam",
+        "refineHexMesh",
+        "refineMesh",
+        "renumberMesh",
+        "snappyHexMesh",
+        "splitBaffles",
+        "splitMeshRegions",
+        "star4ToFoam",
+        "stitchMesh",
+        "tetgenToFoam",
+        "topoSet",
+        "transformPoints",
+    }
+)

--- a/src/services/output_safety.py
+++ b/src/services/output_safety.py
@@ -1,0 +1,212 @@
+"""Shared safeguards for Foam-Agent-owned output directories.
+
+OpenFOAM cases commonly live next to valuable source data.  A generic
+``--overwrite_output`` flag must therefore never be interpreted as permission
+to empty an arbitrary directory.  This module centralises the ownership and
+path checks used by both generated and imported-case workflows.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import tempfile
+from typing import Optional
+
+
+OUTPUT_MARKER_NAME = ".foamagent-output"
+_MARKER_CONTENT = "Foam-Agent managed output directory\n"
+
+
+class OutputDirectorySafetyError(ValueError):
+    """Raised when an output target is unsafe to create or clear."""
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve_path(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _protected_paths() -> set[Path]:
+    """Return roots which are never valid Foam-Agent output directories."""
+    repository_root = _repository_root()
+    protected = {
+        Path("/"),
+        Path.home().resolve(),
+        Path(tempfile.gettempdir()).resolve(),
+        repository_root,
+    }
+    protected.update(repository_root.parents)
+    return protected
+
+
+def _ensure_not_related_to_source(output_root: Path, source_path: Optional[str | Path]) -> None:
+    """Prevent an import target from containing, or being inside, its source."""
+    if source_path is None:
+        return
+
+    source_root = _resolve_path(source_path)
+    try:
+        source_root.relative_to(output_root)
+    except ValueError:
+        pass
+    else:
+        raise OutputDirectorySafetyError(
+            "Import output directory cannot be the source path or an ancestor of it."
+        )
+
+    if source_root.is_dir():
+        try:
+            output_root.relative_to(source_root)
+        except ValueError:
+            return
+        raise OutputDirectorySafetyError(
+            "Import output directory cannot be inside the source case directory."
+        )
+
+
+def validate_output_path(
+    output_path: str | Path,
+    *,
+    source_path: Optional[str | Path] = None,
+) -> Path:
+    """Resolve and validate a dedicated output target without mutating it."""
+    raw_path = Path(output_path).expanduser()
+    # Check every existing path component.  Checking only the leaf permits an
+    # attacker (or a mistaken user) to route a new output through a symlinked
+    # parent, then clear/write the target behind that link.
+    absolute_raw_path = raw_path.absolute()
+    for component in (absolute_raw_path, *absolute_raw_path.parents):
+        if component.is_symlink():
+            raise OutputDirectorySafetyError(
+                "Refusing to use output path through symlinked component: "
+                f"{component}"
+            )
+
+    output_root = raw_path.resolve()
+    # Foundation OpenFOAM v10 rejects case paths containing whitespace in a
+    # number of utilities.  Reject early rather than creating an output that
+    # can be imported but can never execute.
+    if any(character.isspace() for character in str(output_root)):
+        raise OutputDirectorySafetyError(
+            f"OpenFOAM case output path must not contain whitespace: {output_root}"
+        )
+    if output_root in _protected_paths():
+        raise OutputDirectorySafetyError(
+            f"Refusing to use protected broad path as output: {output_root}. "
+            "Choose a dedicated child directory."
+        )
+    _ensure_not_related_to_source(output_root, source_path)
+    return output_root
+
+
+def output_is_owned(output_root: str | Path) -> bool:
+    """Return whether *output_root* was previously initialised by Foam-Agent."""
+    marker = _resolve_path(output_root) / OUTPUT_MARKER_NAME
+    if marker.is_symlink() or not marker.is_file():
+        return False
+    try:
+        return marker.read_text(encoding="utf-8") == _MARKER_CONTENT
+    except OSError:
+        return False
+
+
+def _write_ownership_marker(output_root: Path) -> None:
+    marker = output_root / OUTPUT_MARKER_NAME
+    marker.write_text(_MARKER_CONTENT, encoding="utf-8")
+
+
+def _make_tree_deletable(root: Path) -> None:
+    """Restore owner access required to remove an owned directory tree.
+
+    Imported cases deliberately make the original copy read-only. An overwrite
+    removes that copy before recreating it, so every real directory in the
+    tree needs owner read/write/execute access for shutil.rmtree. Do not
+    traverse or modify symlinks while restoring those permissions.
+    """
+    for directory, directory_names, _ in os.walk(root, topdown=True, followlinks=False):
+        current = Path(directory)
+        directory_names[:] = [
+            name for name in directory_names if not (current / name).is_symlink()
+        ]
+        mode = current.stat(follow_symlinks=False).st_mode
+        current.chmod(mode | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+
+def _clear_children(output_root: Path) -> None:
+    for child in output_root.iterdir():
+        if child.is_symlink():
+            child.unlink()
+        elif child.is_dir():
+            _make_tree_deletable(child)
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
+def validate_output_preparation(
+    output_path: str | Path,
+    *,
+    overwrite: bool,
+    source_path: Optional[str | Path] = None,
+) -> Path:
+    """Check whether an output target may be prepared, without changing it."""
+    output_root = validate_output_path(output_path, source_path=source_path)
+    if not output_root.exists():
+        return output_root
+    if not output_root.is_dir():
+        raise OutputDirectorySafetyError(
+            f"Output path exists and is not a directory: {output_root}"
+        )
+
+    meaningful_children = [
+        child for child in output_root.iterdir() if child.name != OUTPUT_MARKER_NAME
+    ]
+    if not meaningful_children:
+        return output_root
+    if not overwrite:
+        raise FileExistsError(
+            f"Output directory is not empty: {output_root}. "
+            "Choose a new output directory or pass --overwrite_output."
+        )
+    if not output_is_owned(output_root):
+        raise OutputDirectorySafetyError(
+            f"Refusing to clear unowned output directory: {output_root}. "
+            "Use a new dedicated directory instead."
+        )
+    return output_root
+
+
+def prepare_output_directory(
+    output_path: str | Path,
+    *,
+    overwrite: bool,
+    source_path: Optional[str | Path] = None,
+) -> Path:
+    """Create a managed output directory, safely clearing only owned output.
+
+    A non-empty directory may be cleared only if it contains Foam-Agent's
+    ownership marker.  This makes ``--overwrite_output`` safe even if a caller
+    accidentally passes a broad existing directory such as ``/tmp``.
+    """
+    output_root = validate_output_preparation(
+        output_path,
+        overwrite=overwrite,
+        source_path=source_path,
+    )
+    if output_root.exists():
+        meaningful_children = [
+            child for child in output_root.iterdir() if child.name != OUTPUT_MARKER_NAME
+        ]
+        if meaningful_children:
+            _clear_children(output_root)
+    else:
+        output_root.mkdir(parents=True, exist_ok=False)
+
+    _write_ownership_marker(output_root)
+    return output_root

--- a/src/services/plan.py
+++ b/src/services/plan.py
@@ -3,8 +3,10 @@ import re
 from typing import Dict, Any, List, Tuple, Optional
 from pathlib import Path
 from pydantic import BaseModel, Field
-from utils import LLMService, retrieve_faiss, parse_directory_structure
+from utils import retrieve_faiss, parse_directory_structure
+from config import Config
 from . import global_llm_service
+from .case_paths import CasePathSafetyError, safe_case_relative_path
 
 
 class CaseSummaryModel(BaseModel):
@@ -23,7 +25,12 @@ class OpenFOAMPlanModel(BaseModel):
     subtasks: List[SubtaskModel]
 
 
-def parse_requirement_to_case_info(user_requirement: str, case_stats: Dict[str, List[str]]) -> Dict[str, str]:
+def parse_requirement_to_case_info(
+    user_requirement: str,
+    case_stats: Dict[str, List[str]],
+    *,
+    llm_service: Optional[Any] = None,
+) -> Dict[str, str]:
     """
     Parse user requirements into structured case information using LLM.
     
@@ -69,9 +76,15 @@ def parse_requirement_to_case_info(user_requirement: str, case_stats: Dict[str, 
         f"Note: case solver must be one of {case_stats.get('case_solver', [])}."
     )
     parse_user_prompt = f"User requirement: {user_requirement}."
-    res = global_llm_service.invoke(parse_user_prompt, parse_system_prompt, pydantic_obj=CaseSummaryModel)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    res = llm_client.invoke(parse_user_prompt, parse_system_prompt, pydantic_obj=CaseSummaryModel)
+    raw_case_name = res.case_name.replace(" ", "_")
+    try:
+        case_name = safe_case_relative_path("", raw_case_name).name
+    except CasePathSafetyError as exc:
+        raise ValueError(f"Unsafe generated case name: {raw_case_name!r}") from exc
     return {
-        "case_name": res.case_name.replace(" ", "_"),
+        "case_name": case_name,
         "case_domain": res.case_domain,
         "case_category": res.case_category,
         "case_solver": res.case_solver,
@@ -115,6 +128,10 @@ def resolve_case_dir(
     """
     if case_dir:
         return case_dir
+    try:
+        case_name = safe_case_relative_path("", case_name).name
+    except CasePathSafetyError as exc:
+        raise ValueError(f"Unsafe generated case name: {case_name!r}") from exc
     if run_directory is None:
         run_directory = str(Path(__file__).resolve().parent.parent / "runs")
     base_dir = str(run_directory)
@@ -129,6 +146,145 @@ class SimilarCaseAdviceModel(BaseModel):
     advice: str = Field(description="one-sentence advice to include in prompts")
 
 
+_STRUCTURE_RECALL_FLOOR = 200
+_STRUCTURE_RECALL_MULTIPLIER = 20
+_DETAIL_RECALL_FLOOR = 50
+_DETAIL_RECALL_MULTIPLIER = 5
+_REFERENCE_FILE_CONTENT_LIMIT = 20_000
+_REFERENCE_TOTAL_CONTENT_LIMIT = 200_000
+_REFERENCE_FILE_PATTERN = re.compile(
+    r"(<file_begin>\s*file name:\s*[^\n<]+\s*\n<file_content>)(.*?)(</file_content>\s*</file_end>)",
+    re.DOTALL | re.IGNORECASE,
+)
+def _normalise_metadata(value: Any) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _normalise_structure(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip().casefold()
+
+
+def _retrieval_tokens(value: Any) -> List[str]:
+    text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", str(value or ""))
+    return [
+        token.casefold()
+        for token in re.findall(r"[A-Za-z0-9]+", text)
+        if len(token) >= 3
+    ]
+
+
+def _case_name_overlap(item: Dict[str, Any], query_text: str) -> float:
+    name_tokens = set(_retrieval_tokens(item.get("case_name")))
+    if not name_tokens:
+        return 0.0
+    query_tokens = _retrieval_tokens(query_text)
+    return sum(query_tokens.count(token) for token in name_tokens) / len(name_tokens)
+
+
+def _score_value(item: Dict[str, Any]) -> float:
+    score = item.get("score")
+    if score is None:
+        return float("inf")
+    try:
+        return float(score)
+    except (TypeError, ValueError):
+        return float("inf")
+
+
+def _metadata_identity(item: Dict[str, Any]) -> tuple[str, str, str, str]:
+    return tuple(
+        _normalise_metadata(item.get(key))
+        for key in ("case_name", "case_domain", "case_category", "case_solver")
+    )
+
+
+def _extract_directory_structure(item: Dict[str, Any]) -> str:
+    structure = item.get("dir_structure")
+    if structure and _normalise_metadata(structure) != "unknown":
+        return str(structure).strip()
+
+    full_content = str(item.get("full_content") or "")
+    match = re.search(
+        r"<directory_structure>(.*?)</directory_structure>",
+        full_content,
+        re.DOTALL | re.IGNORECASE,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def _allocate_content_budgets(target_lengths: List[int], available: int) -> List[int]:
+    """Distribute a total character budget without penalising small files."""
+    if not target_lengths:
+        return []
+    if available <= 0:
+        return [0] * len(target_lengths)
+    if sum(target_lengths) <= available:
+        return target_lengths
+
+    budgets = [0] * len(target_lengths)
+    remaining = available
+    active = set(range(len(target_lengths)))
+
+    while active:
+        share = remaining // len(active)
+        completed = [idx for idx in active if target_lengths[idx] <= share]
+        if not completed:
+            for offset, idx in enumerate(sorted(active)):
+                budgets[idx] = share + (1 if offset < remaining % len(active) else 0)
+            break
+
+        for idx in completed:
+            budgets[idx] = target_lengths[idx]
+            remaining -= budgets[idx]
+            active.remove(idx)
+
+    return budgets
+
+
+def _crop_file_content(content: str, budget: int) -> str:
+    if len(content) <= budget:
+        return content
+    if budget <= 0:
+        return ""
+
+    marker = f"\n/* [reference content omitted; original_chars={len(content)}] */\n"
+    if budget <= len(marker):
+        return marker[:budget]
+    return marker
+
+
+def _truncate_large_reference_files(
+    reference: str,
+    per_file_limit: int = _REFERENCE_FILE_CONTENT_LIMIT,
+    total_content_limit: int = _REFERENCE_TOTAL_CONTENT_LIMIT,
+) -> str:
+    """Bound tutorial prompt size while retaining its index, tree, and every file name.
+
+    Tutorial details can contain generated meshes, sampled data, or millions of
+    particle positions.  Those data are useful as files in the directory tree but
+    not as verbatim LLM context.  The limits are content-based and intentionally
+    independent of case names and file names.
+    """
+    matches = list(_REFERENCE_FILE_PATTERN.finditer(reference))
+    if not matches:
+        return reference
+
+    original_lengths = [len(match.group(2)) for match in matches]
+    outside_content_length = len(reference) - sum(original_lengths)
+    available = max(0, total_content_limit - outside_content_length)
+    target_lengths = [min(length, max(0, per_file_limit)) for length in original_lengths]
+    budgets = _allocate_content_budgets(target_lengths, available)
+
+    parts: List[str] = []
+    cursor = 0
+    for match, budget in zip(matches, budgets):
+        parts.append(reference[cursor:match.start(2)])
+        parts.append(_crop_file_content(match.group(2), budget))
+        cursor = match.end(2)
+    parts.append(reference[cursor:])
+    return "".join(parts)
+
+
 def _log_top3(label: str, items: List[Dict[str, Any]]) -> None:
     print(f"{label} (top-3):")
     for i, it in enumerate(items[:3], 1):
@@ -140,14 +296,80 @@ def _log_top3(label: str, items: List[Dict[str, Any]]) -> None:
 def _rerank_candidates(
     candidates: List[Dict[str, Any]],
     case_solver: str,
+    query_text: str = "",
 ) -> List[Dict[str, Any]]:
     def key(item: Dict[str, Any]) -> tuple:
-        solver_match = 1 if item.get("case_solver") == case_solver else 0
-        score = item.get("score")
-        score_val = 0.0 if score is None else float(score)
-        return (-solver_match, score_val)
+        solver_match = int(
+            _normalise_metadata(item.get("case_solver"))
+            == _normalise_metadata(case_solver)
+        )
+        return (
+            -solver_match,
+            -_case_name_overlap(item, query_text),
+            _score_value(item),
+        )
 
     return sorted(candidates, key=key)
+
+
+def _retrieve_matching_details(
+    selected: Dict[str, Any],
+    dir_structure: str,
+    recall_k: int,
+    config: Optional[Config] = None,
+) -> Optional[Dict[str, Any]]:
+    """Fetch details for the exact case selected from the structure index."""
+    detail_query = (
+        "<index>\n"
+        f"case name: {selected.get('case_name')}\n"
+        f"case domain: {selected.get('case_domain')}\n"
+        f"case category: {selected.get('case_category')}\n"
+        f"case solver: {selected.get('case_solver')}\n"
+        "</index>\n"
+        f"<directory_structure>\n{dir_structure}\n</directory_structure>"
+    )
+
+    try:
+        kwargs: Dict[str, Any] = {"topk": recall_k}
+        if config is not None:
+            kwargs["config"] = config
+        candidates = retrieve_faiss(
+            "openfoam_tutorials_details",
+            detail_query,
+            **kwargs,
+        )
+    except ValueError as exc:
+        print(f"Warning: Could not retrieve tutorial details: {exc}")
+        return None
+
+    selected_identity = _metadata_identity(selected)
+    exact_matches = [
+        candidate
+        for candidate in candidates
+        if _metadata_identity(candidate) == selected_identity
+    ]
+    if not exact_matches:
+        print(
+            "Warning: Details index did not return the exact case selected from "
+            "the structure index; skipping tutorial contents."
+        )
+        return None
+
+    target_structure = _normalise_structure(dir_structure)
+    exact_structure_matches = [
+        candidate
+        for candidate in exact_matches
+        if _normalise_structure(_extract_directory_structure(candidate))
+        == target_structure
+    ]
+    if not exact_structure_matches:
+        print(
+            "Warning: Details index returned matching case metadata but not the "
+            "same directory structure; skipping tutorial contents."
+        )
+        return None
+
+    return min(exact_structure_matches, key=_score_value)
 
 
 def _build_advice(
@@ -155,6 +377,7 @@ def _build_advice(
     case_info: str,
     selected: Optional[Dict[str, Any]],
     candidates: List[Dict[str, Any]],
+    llm_service: Optional[Any] = None,
 ) -> SimilarCaseAdviceModel:
     cand_lines = [
         f"- {c.get('case_name')} | {c.get('case_domain')} | {c.get('case_category')} | {c.get('case_solver')} | score={c.get('score')}"
@@ -180,7 +403,8 @@ def _build_advice(
         "Return JSON with keys: match_level (high/medium/low/none), use_scope, advice."
     )
 
-    return global_llm_service.invoke(user_prompt, sys_prompt, pydantic_obj=SimilarCaseAdviceModel)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    return llm_client.invoke(user_prompt, sys_prompt, pydantic_obj=SimilarCaseAdviceModel)
 
 
 def retrieve_references(case_name: str,
@@ -188,53 +412,131 @@ def retrieve_references(case_name: str,
                         case_domain: str,
                         case_category: str,
                         searchdocs: int = 2,
-                        user_requirement: str = "") -> Tuple[str, str, str, str, SimilarCaseAdviceModel]:
+                        user_requirement: str = "",
+                        config: Optional[Config] = None,
+                        llm_service: Optional[Any] = None) -> Tuple[str, str, str, str, SimilarCaseAdviceModel]:
     # Build case_info
     case_info = f"case name: {case_name}\ncase domain: {case_domain}\ncase category: {case_category}\ncase solver: {case_solver}"
     print("Retrieval query:\n" + case_info)
 
-    recall_k = max(10, int(searchdocs))
-    faiss_structure_all = retrieve_faiss("openfoam_tutorials_structure", case_info, topk=recall_k)
+    requested_docs = max(1, int(searchdocs))
+    recall_k = max(
+        _STRUCTURE_RECALL_FLOOR,
+        requested_docs * _STRUCTURE_RECALL_MULTIPLIER,
+    )
+    detail_recall_k = max(
+        _DETAIL_RECALL_FLOOR,
+        requested_docs * _DETAIL_RECALL_MULTIPLIER,
+    )
+    retrieval_query = case_info
+    if user_requirement.strip():
+        retrieval_query += f"\nuser requirement: {user_requirement.strip()}"
+
+    structure_kwargs: Dict[str, Any] = {"topk": recall_k}
+    if config is not None:
+        structure_kwargs["config"] = config
+    faiss_structure_all = retrieve_faiss(
+        "openfoam_tutorials_structure",
+        retrieval_query,
+        **structure_kwargs,
+    )
     print(f"Retrieved {len(faiss_structure_all)} candidates from FAISS.")
 
-    # Hard constraint: domain must match
-    domain_matched = [c for c in faiss_structure_all if c.get("case_domain") == case_domain]
-    _log_top3("Domain-matched structure candidates", domain_matched)
+    # Domain and solver are compatibility constraints, not merely semantic hints.
+    domain_matched = [
+        candidate
+        for candidate in faiss_structure_all
+        if _normalise_metadata(candidate.get("case_domain"))
+        == _normalise_metadata(case_domain)
+    ]
+    compatible = [
+        candidate
+        for candidate in domain_matched
+        if _normalise_metadata(candidate.get("case_solver"))
+        == _normalise_metadata(case_solver)
+    ]
+    ranked = _rerank_candidates(compatible, case_solver, retrieval_query)
+    _log_top3("Domain-and-solver-matched structure candidates", ranked)
 
-    if not domain_matched:
-        print(f"No suitable similar case found under domain={case_domain}.")
-        advice = _build_advice(user_requirement, case_info, None, faiss_structure_all)
+    if not ranked:
+        print(
+            "No compatible similar case found under "
+            f"domain={case_domain}, solver={case_solver}."
+        )
+        advice_candidates = _rerank_candidates(
+            domain_matched,
+            case_solver,
+            retrieval_query,
+        )
+        advice = _build_advice(
+            user_requirement,
+            case_info,
+            None,
+            advice_candidates or faiss_structure_all,
+            llm_service,
+        )
         return "", "", "", "", advice
 
-    # Rerank by solver match, then semantic score
-    ranked = _rerank_candidates(domain_matched, case_solver)
     selected = ranked[0]
-
-    # Use details from the same candidate (no re-query on structure text)
-    faiss_detailed = selected.get("full_content", "")
-    faiss_detailed = re.sub(r"\n{3}", "\n", faiss_detailed)
-
-    m = re.search(r"<directory_structure>(.*?)</directory_structure>", faiss_detailed, re.DOTALL)
-    if not m:
-        print("Warning: No directory_structure found in selected similar case details.")
-        advice = _build_advice(user_requirement, case_info, selected, ranked)
+    dir_structure = _extract_directory_structure(selected)
+    if not dir_structure:
+        print("Warning: No directory_structure found in selected similar case.")
+        advice = _build_advice(user_requirement, case_info, selected, ranked, llm_service)
         return "", "", "", "", advice
-    dir_structure = m.group(1).strip()
+
+    # The structure index only contains the file tree.  Fetch the exact same
+    # metadata identity from the details index before exposing file contents.
+    detail = _retrieve_matching_details(
+        selected,
+        dir_structure,
+        detail_recall_k,
+        config=config,
+    )
+    faiss_detailed = ""
+    if detail is not None:
+        faiss_detailed = str(detail.get("full_content") or "")
+        if _normalise_metadata(faiss_detailed) == "unknown":
+            faiss_detailed = ""
+        else:
+            faiss_detailed = re.sub(r"\n{3,}", "\n\n", faiss_detailed)
+            faiss_detailed = _truncate_large_reference_files(faiss_detailed)
+
     dir_counts = parse_directory_structure(dir_structure)
     dir_counts_str = ',\n'.join([f"There are {count} files in Directory: {directory}" for directory, count in dir_counts.items()])
 
     # Build allrun reference
-    index_content = f"<index>\ncase name: {selected.get('case_name')}\ncase solver: {selected.get('case_solver')}\n</index>\n<directory_structure>\n{dir_structure}\n</directory_structure>"
-    faiss_allrun = retrieve_faiss("openfoam_allrun_scripts", index_content, topk=searchdocs)
+    index_content = (
+        "<index>\n"
+        f"case name: {selected.get('case_name')}\n"
+        f"case domain: {selected.get('case_domain')}\n"
+        f"case category: {selected.get('case_category')}\n"
+        f"case solver: {selected.get('case_solver')}\n"
+        "</index>\n"
+        f"<directory_structure>\n{dir_structure}\n</directory_structure>"
+    )
+    allrun_kwargs: Dict[str, Any] = {"topk": requested_docs}
+    if config is not None:
+        allrun_kwargs["config"] = config
+    faiss_allrun = retrieve_faiss(
+        "openfoam_allrun_scripts",
+        index_content,
+        **allrun_kwargs,
+    )
     allrun_reference = "Similar cases are ordered, with smaller numbers indicating greater similarity. For example, similar_case_1 is more similar than similar_case_2, and similar_case_2 is more similar than similar_case_3.\n"
     for idx, item in enumerate(faiss_allrun):
         allrun_reference += f"<similar_case_{idx + 1}>{item['full_content']}</similar_case_{idx + 1}>\n\n\n"
 
-    advice = _build_advice(user_requirement, case_info, selected, ranked)
+    advice = _build_advice(user_requirement, case_info, selected, ranked, llm_service)
     return faiss_detailed, dir_structure, dir_counts_str, allrun_reference, advice
 
 
-def decompose_to_subtasks(user_requirement: str, dir_structure: str, dir_counts_str: str) -> List[Dict]:
+def decompose_to_subtasks(
+    user_requirement: str,
+    dir_structure: str,
+    dir_counts_str: str,
+    *,
+    llm_service: Optional[Any] = None,
+) -> List[Dict]:
     decompose_system_prompt = (
         "You are an experienced Planner specializing in OpenFOAM projects. "
         "Your task is to break down the following user requirement into a series of smaller, manageable subtasks. "
@@ -254,7 +556,8 @@ def decompose_to_subtasks(user_requirement: str, dir_structure: str, dir_counts_
         "Please generate the output as structured JSON."
     )
 
-    res = global_llm_service.invoke(decompose_user_prompt, decompose_system_prompt, pydantic_obj=OpenFOAMPlanModel)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    res = llm_client.invoke(decompose_user_prompt, decompose_system_prompt, pydantic_obj=OpenFOAMPlanModel)
     return [{"file_name": s.file_name, "folder_name": s.folder_name} for s in res.subtasks]
 
 
@@ -262,7 +565,11 @@ def generate_simulation_plan(
     user_requirement: str,
     case_stats: Dict[str, List[str]],
     case_dir: str = "",
-    searchdocs: int = 2
+    searchdocs: int = 2,
+    run_directory: str | Path | None = None,
+    run_times: int = 1,
+    config: Optional[Config] = None,
+    llm_service: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Generate a complete simulation plan by parsing requirements and creating subtasks.
@@ -294,7 +601,11 @@ def generate_simulation_plan(
         RuntimeError: If any step in the planning process fails
     """
     # Step 1: Parse user requirement to case info
-    case_info = parse_requirement_to_case_info(user_requirement, case_stats)
+    case_info = parse_requirement_to_case_info(
+        user_requirement,
+        case_stats,
+        llm_service=llm_service,
+    )
     case_name = case_info["case_name"]
     case_domain = case_info["case_domain"]
     case_category = case_info["case_category"]
@@ -304,8 +615,12 @@ def generate_simulation_plan(
     resolved_case_dir = resolve_case_dir(
         case_name=case_name,
         case_dir=case_dir,
-        run_times=1,
-        run_directory=str(Path(__file__).resolve().parent.parent / "runs")
+        run_times=run_times,
+        run_directory=(
+            str(run_directory)
+            if run_directory is not None
+            else str(Path(__file__).resolve().parent.parent / "runs")
+        ),
     )
     
     # Step 3: Retrieve references
@@ -316,10 +631,17 @@ def generate_simulation_plan(
         case_category=case_category,
         searchdocs=searchdocs,
         user_requirement=user_requirement,
+        config=config,
+        llm_service=llm_service,
     )
     
-    # Step 4: Decompose to subtasks
-    subtasks = decompose_to_subtasks(user_requirement, dir_structure, dir_counts_str)
+    # Step 4: Decompose to subtasks.
+    subtasks = decompose_to_subtasks(
+        user_requirement,
+        dir_structure,
+        dir_counts_str,
+        llm_service=llm_service,
+    )
     
     if len(subtasks) == 0:
         raise ValueError("Failed to generate subtasks.")
@@ -340,5 +662,3 @@ def generate_simulation_plan(
         "subtasks": subtasks,
         "similar_case_advice": advice,
     }
-
-

--- a/src/services/review.py
+++ b/src/services/review.py
@@ -31,6 +31,7 @@ def review_error_logs(
     user_requirement: str,
     similar_case_advice: Optional[Any] = None,
     history_text: Optional[List[str]] = None,
+    llm_service: Optional[Any] = None,
 ) -> Tuple[str, List[str]]:
     """Stateless reviewer: returns (review_analysis, updated_history)."""
     advice_text = ""
@@ -65,7 +66,8 @@ def review_error_logs(
             "Please review the error logs and provide guidance on how to resolve the reported errors. Make sure your suggestions adhere to user requirements and do not contradict it."
         )
 
-    review_response = global_llm_service.invoke(reviewer_user_prompt, REVIEWER_SYSTEM_PROMPT)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    review_response = llm_client.invoke(reviewer_user_prompt, REVIEWER_SYSTEM_PROMPT)
     review_content = review_response
 
     updated_history = list(history_text) if history_text else []
@@ -73,7 +75,7 @@ def review_error_logs(
         f"<Attempt {len(updated_history)//4 + 1}>\n",
         f"<Error_Logs>\n{error_logs}\n</Error_Logs>",
         f"<Review_Analysis>\n{review_content}\n</Review_Analysis>",
-        f"</Attempt>\n",
+        "</Attempt>\n",
     ]
     updated_history.extend(current_attempt)
     return review_content, updated_history
@@ -84,6 +86,7 @@ def generate_rewrite_plan(
     error_logs: List[str],
     review_analysis: str,
     user_requirement: str,
+    llm_service: Optional[Any] = None,
 ) -> dict:
     """Generate a minimal, explicit rewrite plan for downstream rewrite step."""
     planner_system_prompt = (
@@ -107,10 +110,10 @@ def generate_rewrite_plan(
         "Return strict JSON now with key target_files only."
     )
 
-    response = global_llm_service.invoke(
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    response = llm_client.invoke(
         planner_user_prompt,
         planner_system_prompt,
         pydantic_obj=RewritePlan,
     )
     return response.model_dump()
-

--- a/src/services/run_hpc.py
+++ b/src/services/run_hpc.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Dict
+from typing import Any, Optional, Tuple, Dict
 import os
 import json
 import subprocess
@@ -8,7 +8,12 @@ from utils import check_foam_errors, save_file
 from . import global_llm_service
 
 
-def create_slurm_script(case_dir: str, cluster_info: dict) -> str:
+def create_slurm_script(
+    case_dir: str,
+    cluster_info: dict,
+    *,
+    llm_service: Optional[Any] = None,
+) -> str:
     """
     Create a SLURM script for OpenFOAM simulation using LLM.
     
@@ -49,7 +54,8 @@ def create_slurm_script(case_dir: str, cluster_info: dict) -> str:
         f"Generate a complete SLURM script that will run the OpenFOAM simulation using the Allrun script."
     )
     
-    response = global_llm_service.invoke(user_prompt, system_prompt)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    response = llm_client.invoke(user_prompt, system_prompt)
     
     # Clean up the response to extract just the script content
     script_content = response.strip()
@@ -70,7 +76,14 @@ def create_slurm_script(case_dir: str, cluster_info: dict) -> str:
     return script_path
 
 
-def create_slurm_script_with_error_context(case_dir: str, cluster_info: dict, error_message: str = "", previous_script_content: str = "") -> str:
+def create_slurm_script_with_error_context(
+    case_dir: str,
+    cluster_info: dict,
+    error_message: str = "",
+    previous_script_content: str = "",
+    *,
+    llm_service: Optional[Any] = None,
+) -> str:
     """
     Create a SLURM script for OpenFOAM simulation using LLM, with error context for retries.
     
@@ -131,7 +144,8 @@ def create_slurm_script_with_error_context(case_dir: str, cluster_info: dict, er
     
     user_prompt += f"\nGenerate a complete SLURM script that will run the OpenFOAM simulation using the Allrun script. Return ONLY the complete SLURM script content. Do not include any explanations or markdown formatting."
     
-    response = global_llm_service.invoke(user_prompt, system_prompt)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    response = llm_client.invoke(user_prompt, system_prompt)
     
     # Clean up the response to extract just the script content
     script_content = response.strip()
@@ -197,7 +211,12 @@ def check_job(inp: JobStatusIn) -> JobStatusOut:
     return JobStatusOut(status=status if ok else f"error: {err}")
 
 
-def extract_cluster_info_from_requirement(user_requirement: str, case_dir: str) -> Dict:
+def extract_cluster_info_from_requirement(
+    user_requirement: str,
+    case_dir: str,
+    *,
+    llm_service: Optional[Any] = None,
+) -> Dict:
     """
     Extract cluster information from user requirement using LLM.
     
@@ -257,7 +276,8 @@ def extract_cluster_info_from_requirement(user_requirement: str, case_dir: str) 
     
     user_prompt += "Extract cluster information and return as JSON object."
     
-    response = global_llm_service.invoke(user_prompt, system_prompt)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    response = llm_client.invoke(user_prompt, system_prompt)
     
     # Try to parse the JSON response
     try:
@@ -335,5 +355,4 @@ def wait_for_job(job_id: str, max_wait_time: int = 3600, wait_interval: int = 30
         time.sleep(wait_interval)
         elapsed += wait_interval
     return last_status or "TIMEOUT", True, ""
-
 

--- a/src/services/run_local.py
+++ b/src/services/run_local.py
@@ -1,14 +1,426 @@
 import os
 import re
-from typing import List, Any
-from models import RunIn, RunOut
-from utils import remove_files, remove_file, remove_numeric_folders, run_command, check_foam_errors
+import math
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from models import RunOut
+from utils import remove_numeric_folders, run_command, check_foam_errors
+from .allrun_commands import (
+    application_positions as allrun_application_positions,
+    command_positions as allrun_command_positions,
+    script_without_comments as allrun_script_without_comments,
+)
+from .openfoam_commands import MESH_MUTATING_COMMANDS
+
+
+_MESH_GENERATION_COMMANDS = MESH_MUTATING_COMMANDS
+_FOAM_POINT_RE = re.compile(
+    r"\(\s*([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
+    r"\s+([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
+    r"\s+([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)\s*\)"
+)
+
+
+def _validation_error(file_name: str, message: str) -> Dict[str, str]:
+    return {"file": file_name, "error_content": message}
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _strip_foam_comments(content: str) -> str:
+    """Remove OpenFOAM line and block comments before light syntax checks."""
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    return re.sub(r"//.*$", "", content, flags=re.MULTILINE)
+
+
+def _control_dict_application(case_dir: str) -> Optional[str]:
+    control_dict = _read_text(Path(case_dir) / "system" / "controlDict")
+    control_dict = _strip_foam_comments(control_dict)
+    match = re.search(r"\bapplication\s+([^\s;]+)\s*;", control_dict)
+    return match.group(1) if match else None
+
+
+def _mesh_generation_positions(allrun_script: str) -> List[int]:
+    positions = []
+    for command in _MESH_GENERATION_COMMANDS:
+        positions.extend(allrun_command_positions(allrun_script, command))
+    return sorted(positions)
+
+
+def validate_momentum_transport_dictionaries(case_dir: str) -> List[str]:
+    """Require the Foundation transport-model selector when such a file exists.
+
+    The check is filename- and syntax-based, not solver- or case-specific.  It
+    supports both single-phase ``momentumTransport`` and phase-qualified
+    ``momentumTransport.<phase>`` files.
+    """
+    constant_dir = Path(case_dir) / "constant"
+    try:
+        dictionaries = sorted(
+            path for path in constant_dir.glob("momentumTransport*")
+            if path.is_file()
+        )
+    except OSError:
+        return []
+
+    issues: List[str] = []
+    for dictionary in dictionaries:
+        content = _strip_foam_comments(_read_text(dictionary))
+        if not re.search(r"\bsimulationType\s+[^\s;]+\s*;", content):
+            issues.append(
+                f"constant/{dictionary.name} is missing the required Foundation "
+                "OpenFOAM simulationType entry"
+            )
+    return issues
+
+
+def _balanced_foam_block(text: str, keyword: str, opener: str, closer: str) -> str:
+    """Return a balanced OpenFOAM list/dictionary body following *keyword*.
+
+    This intentionally handles only the balanced delimiters needed for the
+    light-weight semantic checks below; OpenFOAM itself remains the authority
+    for complete dictionary parsing.
+    """
+    match = re.search(rf"\b{re.escape(keyword)}\b", text)
+    if not match:
+        return ""
+    start = text.find(opener, match.end())
+    if start < 0:
+        return ""
+    depth = 0
+    for index in range(start, len(text)):
+        char = text[index]
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start + 1:index]
+    return ""
+
+
+def _blockmesh_boundary_patches(content: str) -> List[tuple[str, str, str]]:
+    """Extract top-level ``boundary`` patch names, types, and faces text."""
+    boundary = _balanced_foam_block(content, "boundary", "(", ")")
+    patches: List[tuple[str, str, str]] = []
+    cursor = 0
+    while cursor < len(boundary):
+        match = re.search(r"\b([A-Za-z_][\w.-]*)\s*\{", boundary[cursor:])
+        if not match:
+            break
+        name = match.group(1)
+        opening = cursor + match.end() - 1
+        depth = 0
+        closing = -1
+        for index in range(opening, len(boundary)):
+            if boundary[index] == "{":
+                depth += 1
+            elif boundary[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    closing = index
+                    break
+        if closing < 0:
+            break
+        patch = boundary[opening + 1:closing]
+        type_match = re.search(r"\btype\s+([^\s;]+)\s*;", patch)
+        faces = _balanced_foam_block(patch, "faces", "(", ")")
+        patches.append((name, type_match.group(1) if type_match else "", faces))
+        cursor = closing + 1
+    return patches
+
+
+def _canonical_face_plane(
+    face: List[int],
+    vertices: List[tuple[float, float, float]],
+) -> Optional[tuple[tuple[float, float, float], float]]:
+    """Return a sign-independent plane normal and offset for one mesh face."""
+    if len(face) < 3 or any(index < 0 or index >= len(vertices) for index in face):
+        return None
+    first, second, third = (vertices[index] for index in face[:3])
+    edge_a = tuple(second[i] - first[i] for i in range(3))
+    edge_b = tuple(third[i] - first[i] for i in range(3))
+    normal = (
+        edge_a[1] * edge_b[2] - edge_a[2] * edge_b[1],
+        edge_a[2] * edge_b[0] - edge_a[0] * edge_b[2],
+        edge_a[0] * edge_b[1] - edge_a[1] * edge_b[0],
+    )
+    magnitude = math.sqrt(sum(component * component for component in normal))
+    if magnitude == 0:
+        return None
+    normal = tuple(component / magnitude for component in normal)
+    for component in normal:
+        if abs(component) > 1e-12:
+            if component < 0:
+                normal = tuple(-value for value in normal)
+            break
+    return normal, sum(normal[i] * first[i] for i in range(3))
+
+
+def validate_blockmesh_symmetry_planes(case_dir: str) -> List[str]:
+    """Catch a frequent invalid ``symmetryPlane`` construction before running.
+
+    A ``symmetryPlane`` patch represents one plane.  This check is deliberately
+    geometry-only: it neither knows the case name nor rewrites generated input.
+    It simply reports a violation for the normal LLM/reviewer repair loop.
+    """
+    content = _read_text(Path(case_dir) / "system" / "blockMeshDict")
+    if not content:
+        return []
+    vertices_body = _balanced_foam_block(content, "vertices", "(", ")")
+    vertices = [
+        tuple(float(component) for component in match.groups())
+        for match in _FOAM_POINT_RE.finditer(vertices_body)
+    ]
+    if not vertices:
+        return []
+
+    issues: List[str] = []
+    face_pattern = re.compile(r"\(\s*((?:\d+\s+)*\d+)\s*\)")
+    for name, patch_type, faces_body in _blockmesh_boundary_patches(content):
+        if patch_type != "symmetryPlane":
+            continue
+        faces = [
+            [int(index) for index in match.group(1).split()]
+            for match in face_pattern.finditer(faces_body)
+        ]
+        planes = [
+            _canonical_face_plane(face, vertices)
+            for face in faces
+        ]
+        planes = [plane for plane in planes if plane is not None]
+        if len(planes) < 2:
+            continue
+        reference_normal, reference_offset = planes[0]
+        tolerance = 1e-9
+        for normal, offset in planes[1:]:
+            normal_alignment = sum(
+                reference_normal[index] * normal[index]
+                for index in range(3)
+            )
+            if normal_alignment < 1 - tolerance or abs(offset - reference_offset) > tolerance:
+                issues.append(
+                    "Preflight failed: system/blockMeshDict patch "
+                    f"{name!r} declares type symmetryPlane but contains faces on "
+                    "different planes. Use type symmetry or one symmetryPlane "
+                    "patch per plane."
+                )
+                break
+    return issues
+
+
+def validate_openfoam_case_preflight(
+    case_dir: str,
+    allrun_script: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """Validate generic execution contracts before launching OpenFOAM."""
+    allrun_path = Path(case_dir) / "Allrun"
+    script = allrun_script if allrun_script is not None else _read_text(allrun_path)
+    script_without_comments = allrun_script_without_comments(script)
+    errors: List[Dict[str, str]] = []
+
+    mesh_positions = _mesh_generation_positions(script_without_comments)
+    if allrun_command_positions(script_without_comments, "blockMesh"):
+        errors.extend(
+            _validation_error("system/blockMeshDict", message)
+            for message in validate_blockmesh_symmetry_planes(case_dir)
+        )
+    errors.extend(
+        _validation_error("constant/momentumTransport", message)
+        for message in validate_momentum_transport_dictionaries(case_dir)
+    )
+    check_mesh_positions = allrun_command_positions(script_without_comments, "checkMesh")
+    application = _control_dict_application(case_dir)
+    application_positions = allrun_application_positions(script_without_comments, application)
+    if mesh_positions:
+        last_mesh_position = max(mesh_positions)
+        valid_check_positions = [
+            position for position in check_mesh_positions
+            if position > last_mesh_position
+        ]
+        if not valid_check_positions:
+            errors.append(_validation_error(
+                "Allrun",
+                "Preflight failed: Allrun generates or imports a mesh but does not "
+                "run checkMesh after mesh generation.",
+            ))
+
+        # A few official mesh tutorials declare ``blockMesh`` itself as the
+        # controlDict application.  In that case it is a mesh utility, not a
+        # solver that must be preceded by checkMesh: the correct order is
+        # blockMesh followed by checkMesh.  Keep the stricter gate for actual
+        # solvers, which must not start until the mesh check has passed.
+        if (
+            valid_check_positions
+            and application_positions
+            and application not in _MESH_GENERATION_COMMANDS
+        ):
+            first_solver_position = min(application_positions)
+            has_check_before_solver = any(
+                last_mesh_position < position < first_solver_position
+                for position in check_mesh_positions
+            )
+            if not has_check_before_solver:
+                errors.append(_validation_error(
+                    "Allrun",
+                    "Preflight failed: checkMesh must run after mesh generation and "
+                    f"before the configured solver {application}.",
+                ))
+    elif (
+        check_mesh_positions
+        and application_positions
+        and application not in _MESH_GENERATION_COMMANDS
+    ):
+        # A custom mesh can be converted before Allrun is generated. In that
+        # workflow there is no generator command in Allrun, but the quality
+        # gate must still precede the solver.
+        if min(check_mesh_positions) >= min(application_positions):
+            errors.append(_validation_error(
+                "Allrun",
+                "Preflight failed: checkMesh must run before the configured "
+                f"solver {application}.",
+            ))
+
+    return errors
+
+
+def _matching_log_files(case_dir: str, prefix: str) -> List[Path]:
+    case_path = Path(case_dir)
+    try:
+        return sorted(
+            path for path in case_path.iterdir()
+            if path.is_file() and path.name.startswith(prefix)
+        )
+    except OSError:
+        return []
+
+
+def validate_openfoam_case_postflight(
+    case_dir: str,
+    allrun_script: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """Validate mesh and solver evidence after Allrun has exited."""
+    allrun_path = Path(case_dir) / "Allrun"
+    script = allrun_script if allrun_script is not None else _read_text(allrun_path)
+    script_without_comments = allrun_script_without_comments(script)
+    errors: List[Dict[str, str]] = []
+
+    mesh_positions = _mesh_generation_positions(script_without_comments)
+    check_mesh_positions = allrun_command_positions(script_without_comments, "checkMesh")
+    allrun_output = _read_text(Path(case_dir) / "Allrun.out")
+    if mesh_positions or check_mesh_positions:
+        check_mesh_logs = _matching_log_files(case_dir, "log.checkMesh")
+        mesh_evidence = [_read_text(path) for path in check_mesh_logs]
+        if allrun_output:
+            # Backward compatibility for hand-written Allrun scripts which
+            # invoke checkMesh directly instead of through runApplication.
+            mesh_evidence.append(allrun_output)
+        if not mesh_evidence:
+            errors.append(_validation_error(
+                "log.checkMesh",
+                "Postflight failed: mesh validation was requested, but "
+                "neither log.checkMesh nor Allrun.out was produced.",
+            ))
+        elif not any(
+            re.search(r"\bMesh\s+OK\b", content, re.IGNORECASE)
+            for content in mesh_evidence
+        ):
+            errors.append(_validation_error(
+                "log.checkMesh",
+                "Postflight failed: checkMesh did not report 'Mesh OK'.",
+            ))
+
+    application = _control_dict_application(case_dir)
+    if application and application not in _MESH_GENERATION_COMMANDS:
+        solver_logs = _matching_log_files(case_dir, f"log.{application}")
+        solver_evidence = [_read_text(path) for path in solver_logs]
+        # Direct command scripts do not use RunFunctions and write to the
+        # combined Allrun output instead.  Treat that as evidence only if the
+        # script demonstrably invokes the configured application.
+        if not solver_evidence and allrun_application_positions(script_without_comments, application):
+            solver_evidence.append(allrun_output)
+        if not solver_evidence:
+            errors.append(_validation_error(
+                f"log.{application}",
+                "Postflight failed: the configured solver did not produce a log file.",
+            ))
+        elif not any(re.search(r"\bEnd\b", content) for content in solver_evidence):
+            errors.append(_validation_error(
+                f"log.{application}",
+                "Postflight failed: solver output does not contain the OpenFOAM End marker.",
+            ))
+
+    return errors
+
+
+def _result_field(result: Any, name: str, default: Any = None) -> Any:
+    """Read a run result while remaining compatible with older monkeypatches."""
+    if isinstance(result, dict):
+        return result.get(name, default)
+    return getattr(result, name, default)
+
+
+def _deduplicate_errors(errors: List[Any]) -> List[Any]:
+    deduplicated = []
+    seen = set()
+    for error in errors:
+        if isinstance(error, dict):
+            key = (error.get("file"), error.get("error_content"))
+        else:
+            key = str(error)
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(error)
+    return deduplicated
+
+
+def _cleanup_run_artifacts(case_dir: str) -> None:
+    """Remove only disposable solver outputs before a local retry.
+
+    A retry must not inherit processor partitions, post-processing output, or
+    numeric result times from a failed previous execution.  The ``0`` initial
+    condition and all dictionaries are deliberately retained.  This routine
+    is used only for generated/local cases; imported cases use their stricter
+    original-to-work restore mechanism.
+    """
+    root = Path(case_dir)
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        try:
+            if entry.is_symlink():
+                # A case output symlink is not a valid solver artifact, but
+                # unlinking the link never follows it.
+                if entry.name.startswith("log"):
+                    entry.unlink()
+                continue
+            if entry.is_file() and (
+                entry.name.startswith("log")
+                or entry.name in {"Allrun.out", "Allrun.err"}
+            ):
+                entry.unlink()
+            elif entry.is_dir() and (
+                re.fullmatch(r"processor\d+", entry.name)
+                or entry.name in {"postProcessing", "VTK"}
+            ):
+                shutil.rmtree(entry)
+        except OSError as exc:
+            raise RuntimeError(f"Unable to clean prior run artifact {entry}: {exc}") from exc
+    remove_numeric_folders(case_dir)
 
 def run_allrun_and_collect_errors(
     case_dir: str,
     timeout: int = 3600,
     max_retries: int = 1
-) -> List[str]:
+) -> List[Any]:
     """
     Execute the Allrun script and collect any error logs from the simulation.
     
@@ -22,7 +434,7 @@ def run_allrun_and_collect_errors(
         max_retries (int, optional): Maximum number of retry attempts. Defaults to 3.
     
     Returns:
-        List[str]: List of error messages found in the simulation logs.
+        List[Any]: Structured error records found in the simulation logs.
                  Empty list indicates successful execution with no errors.
     
     Raises:
@@ -44,35 +456,58 @@ def run_allrun_and_collect_errors(
     allrun_file_path = os.path.join(case_dir, "Allrun")
     if not os.path.exists(allrun_file_path):
         return [f"Allrun script not found at {allrun_file_path}"]
+
+    allrun_script = _read_text(Path(allrun_file_path))
+    preflight_errors = validate_openfoam_case_preflight(case_dir, allrun_script)
+    if preflight_errors:
+        return preflight_errors
     
     out_file = os.path.join(case_dir, "Allrun.out")
     err_file = os.path.join(case_dir, "Allrun.err")
 
-    # Cleanup
-    remove_files(case_dir, prefix="log")
-    remove_file(err_file)
-    remove_file(out_file)
-    remove_numeric_folders(case_dir)
+    # Cleanup artifacts from an earlier failed invocation before execution.
+    _cleanup_run_artifacts(case_dir)
 
     last_error_logs = []
 
     # Run with retries
     for attempt in range(1, max_retries + 1):
         print(f"Running Allrun (attempt {attempt}/{max_retries})")
-        run_command(allrun_file_path, out_file, err_file, case_dir, timeout)
+        command_result = run_command(
+            allrun_file_path,
+            out_file,
+            err_file,
+            case_dir,
+            timeout,
+        )
 
         # Inspect
-        error_logs = check_foam_errors(case_dir)
+        error_logs: List[Any] = []
+        timed_out = bool(_result_field(command_result, "timed_out", False))
+        returncode = _result_field(command_result, "returncode", 0)
+        if timed_out:
+            error_logs.append(_validation_error(
+                "Allrun",
+                f"Allrun exceeded the {timeout} second execution timeout.",
+            ))
+        elif returncode not in (None, 0):
+            error_logs.append(_validation_error(
+                "Allrun",
+                f"Allrun exited with non-zero return code {returncode}.",
+            ))
+
+        error_logs.extend(check_foam_errors(case_dir))
+        error_logs.extend(
+            validate_openfoam_case_postflight(case_dir, allrun_script)
+        )
+        error_logs = _deduplicate_errors(error_logs)
         if len(error_logs) == 0:
             return []
 
         last_error_logs = error_logs
         if attempt < max_retries:
             print("Allrun reported errors; retrying after cleanup...")
-            remove_files(case_dir, prefix="log")
-            remove_file(err_file)
-            remove_file(out_file)
-            remove_numeric_folders(case_dir)
+            _cleanup_run_artifacts(case_dir)
 
     return last_error_logs
 
@@ -116,5 +551,3 @@ def run_simulation_local(
     errors = run_allrun_and_collect_errors(case_dir, timeout, max_retries)
     status = "completed" if len(errors) == 0 else "failed"
     return RunOut(job_id=None, status=status)
-
-

--- a/src/services/visualization.py
+++ b/src/services/visualization.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import subprocess
-from typing import List, Tuple, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 from utils import save_file
 from . import global_llm_service
 
@@ -33,7 +34,7 @@ def ensure_foam_file(case_dir: str) -> str:
     
     # Create or update the .foam file
     if not os.path.exists(foam_path):
-        with open(foam_path, 'w') as f:
+        with open(foam_path, "w", encoding="utf-8"):
             pass
     else:
         # Update timestamp if file exists
@@ -46,7 +47,10 @@ def generate_pyvista_script(
     case_dir: str,
     foam_file: str,
     user_requirement: str,
-    previous_errors: List[str]
+    previous_errors: List[str],
+    *,
+    output_png: str = "visualization.png",
+    llm_service: Optional[Any] = None,
 ) -> str:
     """
     Generate PyVista visualization script for OpenFOAM case using LLM.
@@ -84,10 +88,12 @@ def generate_pyvista_script(
     prompt = (
         f"<case_directory>{case_dir}</case_directory>\n"
         f"<foam_file>{foam_file}</foam_file>\n"
+        f"<required_output_png>{output_png}</required_output_png>\n"
         f"<visualization_requirements>{user_requirement}</visualization_requirements>\n"
         f"<previous_errors>{previous_errors}</previous_errors>\n"
     )
-    return global_llm_service.invoke(prompt, system_prompt)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    return llm_client.invoke(prompt, system_prompt)
 
 
 def run_pyvista_script(
@@ -108,10 +114,39 @@ def run_pyvista_script(
     script_path = os.path.join(case_dir, filename)
     save_file(script_path, script)
 
-    expected_png_abs = os.path.abspath(os.path.join(case_dir, expected_png)) if expected_png else None
+    expected_png_abs = None
+    if expected_png:
+        case_root = Path(case_dir).resolve()
+        requested_path = case_root / expected_png
+        expected_path = requested_path.resolve()
+        try:
+            expected_path.relative_to(case_root)
+        except ValueError:
+            return False, "", [
+                "Expected visualization artifact must remain inside the case directory",
+                f"expected_png={expected_png}",
+            ]
+        if requested_path.is_symlink():
+            return False, "", [
+                "Expected visualization artifact must not be a symbolic link",
+                f"expected_png={requested_path}",
+            ]
+        if expected_path.exists():
+            if expected_path.is_dir():
+                return False, "", [
+                    "Expected visualization artifact is an existing directory",
+                    f"expected_png={expected_path}",
+                ]
+            if not expected_path.is_file():
+                return False, "", [
+                    "Expected visualization artifact is not a regular file",
+                    f"expected_png={expected_path}",
+                ]
+            expected_path.unlink()
+        expected_png_abs = str(expected_path)
 
     try:
-        completed = subprocess.run(
+        subprocess.run(
             [sys.executable, script_path],
             cwd=case_dir,
             check=True,
@@ -121,7 +156,11 @@ def run_pyvista_script(
         )
 
         if expected_png_abs:
-            if os.path.exists(expected_png_abs) and os.path.getsize(expected_png_abs) > 0:
+            if (
+                os.path.isfile(expected_png_abs)
+                and not os.path.islink(expected_png_abs)
+                and os.path.getsize(expected_png_abs) > 0
+            ):
                 return True, expected_png_abs, []
             return False, "", [
                 "Visualization script executed but expected PNG was not created",
@@ -155,20 +194,29 @@ def run_pyvista_script(
     except FileNotFoundError:
         return False, "", [f"Python interpreter not found: {sys.executable}"]
 
-    except Exception as e:
-        return False, "", [f"Unexpected error running visualization script: {str(e)}"]
+    except OSError as e:
+        return False, "", [f"Unable to run visualization script: {e}"]
 
 
-def fix_pyvista_script(foam_file: str, original_script: str, error_logs: List[str]) -> str:
+def fix_pyvista_script(
+    foam_file: str,
+    original_script: str,
+    error_logs: List[str],
+    *,
+    output_png: str = "visualization.png",
+    llm_service: Optional[Any] = None,
+) -> str:
     system_prompt = (
         "You are an expert in PyVista visualization. Fix the provided script to load the .foam file, render geometry, and save a PNG with colorbar. Return ONLY Python code."
     )
     prompt = (
         f"<error_logs>{error_logs}</error_logs>\n"
         f"<foam_file>{foam_file}</foam_file>\n"
+        f"<required_output_png>{output_png}</required_output_png>\n"
         f"<original_script>{original_script}</original_script>\n"
     )
-    return global_llm_service.invoke(prompt, system_prompt)
+    llm_client = llm_service if llm_service is not None else global_llm_service
+    return llm_client.invoke(prompt, system_prompt)
 
 
 def generate_deterministic_pyvista_script(
@@ -198,11 +246,14 @@ try:
 except Exception:
     pass
 
-try:
-    pv.start_xvfb()
-except Exception:
-    # start_xvfb is optional and may be unavailable
-    pass
+if not os.environ.get('DISPLAY'):
+    try:
+        pv.start_xvfb()
+    except Exception as exc:
+        raise RuntimeError(
+            'Headless visualization requires Xvfb (or a preconfigured DISPLAY). '
+            'Install Xvfb in the runtime image or set DISPLAY explicitly.'
+        ) from exc
 
 foam_path = os.path.abspath({foam_file!r})
 out_png = os.path.abspath({output_png!r})
@@ -265,7 +316,9 @@ else:
     plotter.add_mesh(mesh, color='lightgray')
 
 plotter.view_isometric()
-plotter.show(auto_close=False)
+# ``show()`` can enter an interactive event loop even when off-screen mode is
+# requested (notably in containerized VTK builds). ``screenshot`` renders the
+# scene itself, so skipping ``show`` keeps this generated script batch-safe.
 plotter.screenshot(out_png)
 plotter.close()
 
@@ -273,3 +326,186 @@ print('Wrote', out_png)
 """
 
 
+def _visualization_success(
+    *,
+    case_dir: str,
+    field_name: str,
+    output_image: str,
+    script: str,
+    strategy: str,
+) -> Dict[str, Any]:
+    """Build the stable workflow payload for a successful visualization."""
+    return {
+        "plot_configs": [
+            {
+                "plot_type": "pyvista",
+                "field_name": field_name,
+                "time_step": "latest",
+                "output_format": "png",
+                "output_path": output_image,
+            }
+        ],
+        "plot_outputs": [output_image],
+        "visualization_summary": {
+            "total_plots_generated": 1,
+            "plot_types": ["pyvista"],
+            "fields_visualized": [field_name],
+            "output_directory": case_dir,
+            "pyvista_success": True,
+            "used": strategy,
+        },
+        "pyvista_visualization": {
+            "success": True,
+            "output_image": output_image,
+            "script": script,
+            "used": strategy,
+        },
+    }
+
+
+def _visualization_failure(
+    *,
+    case_dir: str | None,
+    error_message: str,
+    error_logs: List[str] | None = None,
+) -> Dict[str, Any]:
+    """Build the stable workflow payload for a failed visualization."""
+    logs = error_logs or []
+    summary: Dict[str, Any] = {
+        "total_plots_generated": 0,
+        "plot_types": [],
+        "fields_visualized": [],
+        "output_directory": case_dir,
+        "pyvista_success": False,
+        "error": error_message,
+    }
+    visualization: Dict[str, Any] = {"success": False, "error": error_message}
+    if logs:
+        summary["error_logs"] = logs
+        visualization["error_logs"] = logs
+    return {
+        "plot_configs": [],
+        "plot_outputs": [],
+        "visualization_summary": summary,
+        "pyvista_visualization": visualization,
+    }
+
+
+def visualize_case(
+    case_dir: str | None,
+    user_requirement: str,
+    *,
+    max_loop: int = 2,
+    llm_service: Optional[Any] = None,
+    timeout_s: int = 180,
+    allow_llm_fallback: bool = True,
+) -> Dict[str, Any]:
+    """Render a case, optionally falling back from deterministic rendering to LLM repair.
+
+    This owns visualization execution and its stable result contract, leaving the
+    LangGraph node as an adapter.  A generated image is accepted only when it is
+    written at the declared path by :func:`run_pyvista_script`.
+    """
+    if not case_dir:
+        return _visualization_failure(case_dir=None, error_message="Missing case_dir")
+
+    case_dir = os.path.abspath(case_dir)
+    if not os.path.isdir(case_dir):
+        return _visualization_failure(
+            case_dir=case_dir,
+            error_message=f"Case directory does not exist: {case_dir}",
+        )
+
+    foam_file = ensure_foam_file(case_dir)
+    output_png = "visualization.png"
+    field_name = "U"
+    error_logs: List[str] = []
+
+    deterministic_script = generate_deterministic_pyvista_script(
+        foam_file=foam_file,
+        output_png=output_png,
+        field_preference=field_name,
+    )
+    success, output_image, errors = run_pyvista_script(
+        case_dir,
+        deterministic_script,
+        filename="visualization.py",
+        expected_png=output_png,
+        timeout_s=timeout_s,
+    )
+    if success and output_image:
+        return _visualization_success(
+            case_dir=case_dir,
+            field_name=field_name,
+            output_image=output_image,
+            script=deterministic_script,
+            strategy="deterministic_template",
+        )
+    error_logs.extend(errors)
+
+    if not allow_llm_fallback:
+        return _visualization_failure(
+            case_dir=case_dir,
+            error_message="Deterministic visualization failed and LLM fallback is disabled.",
+            error_logs=error_logs,
+        )
+
+    for attempt in range(1, max_loop + 1):
+        print(f"LLM visualization attempt {attempt} of {max_loop}")
+        generated_script = generate_pyvista_script(
+            case_dir,
+            foam_file,
+            user_requirement,
+            error_logs[-2:],
+            output_png=output_png,
+            llm_service=llm_service,
+        )
+        success, output_image, errors = run_pyvista_script(
+            case_dir,
+            generated_script,
+            filename="visualization_llm.py",
+            expected_png=output_png,
+            timeout_s=timeout_s,
+        )
+        if success and output_image:
+            return _visualization_success(
+                case_dir=case_dir,
+                field_name=field_name,
+                output_image=output_image,
+                script=generated_script,
+                strategy="llm_script",
+            )
+        error_logs.extend(errors)
+
+        if attempt == max_loop:
+            continue
+
+        fixed_script = fix_pyvista_script(
+            foam_file,
+            generated_script,
+            error_logs[-2:],
+            output_png=output_png,
+            llm_service=llm_service,
+        )
+        success, output_image, errors = run_pyvista_script(
+            case_dir,
+            fixed_script,
+            filename="visualization_fixed.py",
+            expected_png=output_png,
+            timeout_s=timeout_s,
+        )
+        if success and output_image:
+            return _visualization_success(
+                case_dir=case_dir,
+                field_name=field_name,
+                output_image=output_image,
+                script=fixed_script,
+                strategy="llm_fixed_script",
+            )
+        error_logs.extend(errors)
+
+    return _visualization_failure(
+        case_dir=case_dir,
+        error_message=f"Visualization failed after {max_loop} LLM attempts",
+        error_logs=error_logs,
+    )

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,13 +9,14 @@ from langchain.chat_models import init_chat_model
 from langchain_community.vectorstores import FAISS
 from langchain_openai.embeddings import OpenAIEmbeddings
 import tiktoken
-from langchain_aws import ChatBedrock, ChatBedrockConverse
+from langchain_aws import ChatBedrockConverse
 from langchain_anthropic import ChatAnthropic
 from pathlib import Path
 import tracking_aws
 import requests
 import time
 import random
+import threading
 from botocore.exceptions import ClientError
 import shutil
 from config import Config
@@ -26,8 +27,29 @@ except ImportError:
     HuggingFaceEmbeddings = None
 
 
-# Global dictionary to store loaded FAISS databases
-FAISS_DB_CACHE = {}
+FAISSCacheKey = tuple[str, str, str]
+
+# Cache FAISS indices by their full retrieval configuration.  A process can
+# serve more than one workflow (notably through MCP), so a single global index
+# set would otherwise mix embeddings or tutorial corpora from unrelated
+# Config instances.
+FAISS_DB_CACHE: Dict[FAISSCacheKey, Dict[str, Any]] = {}
+_FAISS_DB_CACHE_LOCK = threading.RLock()
+
+
+def _configured_database_path(config: Config) -> Path:
+    """Resolve the configured database root without silently using the repo one."""
+    configured_path = getattr(config, "database_path", None)
+    if not configured_path:
+        configured_path = Path(__file__).resolve().parent.parent / "database"
+    return Path(configured_path).expanduser().resolve()
+
+
+def _faiss_cache_key(config: Config) -> FAISSCacheKey:
+    """Return the cache identity for one embedding/index configuration."""
+    provider = str(getattr(config, "embedding_provider", "openai") or "openai").casefold()
+    model = str(getattr(config, "embedding_model", "") or "")
+    return (str(_configured_database_path(config)), provider, model)
 
 def get_embedding_model(config: Optional[Config] = None):
     """Return an embedding model based on the provided config.
@@ -59,7 +81,7 @@ def load_faiss_dbs(config: Optional[Config] = None):
     cfg = config or Config()
     embedding_model = get_embedding_model(cfg)
 
-    base_dir = Path(__file__).resolve().parent.parent / "database" / "faiss"
+    base_dir = _configured_database_path(cfg) / "faiss"
 
     # Sanitize model name for directory usage
     model_dir_name = (cfg.embedding_model or "").replace("/", "_").replace(":", "_")
@@ -82,7 +104,7 @@ def load_faiss_dbs(config: Optional[Config] = None):
                 dbs[index] = FAISS.load_local(
                     str(index_path), embedding_model, allow_dangerous_deserialization=True
                 )
-            except Exception as e:
+            except (OSError, RuntimeError, ValueError) as e:
                 print(f"Failed to load index {index}: {e}")
         else:
             print(f"Warning: Index path does not exist: {index_path}")
@@ -90,9 +112,21 @@ def load_faiss_dbs(config: Optional[Config] = None):
     return dbs
 
 
-# Default DB cache (uses default Config()). If you change embedding settings at runtime,
-# call load_faiss_dbs(custom_config) and replace FAISS_DB_CACHE.
-FAISS_DB_CACHE = load_faiss_dbs()
+# The embedding model can be large and may require a network/cache lookup.
+# Defer it until a workflow actually performs retrieval; importing a service
+# that does not use RAG (for example preflight validation) must stay local and
+# deterministic.
+def _ensure_faiss_dbs_loaded(config: Optional[Config] = None) -> Dict[str, Any]:
+    """Load and return the index set matching ``config`` exactly once."""
+    cfg = config or Config()
+    cache_key = _faiss_cache_key(cfg)
+    with _FAISS_DB_CACHE_LOCK:
+        # An empty mapping is also a cached result: repeatedly attempting to
+        # load a missing index set is expensive and obscures the original
+        # configuration error.
+        if cache_key not in FAISS_DB_CACHE:
+            FAISS_DB_CACHE[cache_key] = load_faiss_dbs(cfg)
+        return FAISS_DB_CACHE[cache_key]
 
 class FoamfilePydantic(BaseModel):
     file_name: str = Field(description="Name of the OpenFOAM input file")
@@ -147,7 +181,7 @@ class _CodexResponsesWrapper:
         # We default to a modern tokenizer; adjust if you need model-specific counting.
         try:
             self._enc = tiktoken.get_encoding("o200k_base")
-        except Exception:
+        except (KeyError, ValueError):
             self._enc = tiktoken.get_encoding("cl100k_base")
 
     def get_num_tokens(self, text: str) -> int:
@@ -271,8 +305,7 @@ class _CodexResponsesWrapper:
                 break
             yield data
 
-    def invoke(self, messages):
-        url = f"{self._base_url}/responses"
+    def _response_headers(self) -> dict[str, str]:
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
@@ -281,66 +314,65 @@ class _CodexResponsesWrapper:
         }
         if self._account_id:
             headers["ChatGPT-Account-Id"] = self._account_id
+        return headers
 
+    def _post_responses_request(self, messages) -> requests.Response:
+        """Send one Responses request and preserve useful HTTP failure detail."""
+        url = f"{self._base_url}/responses"
         payload = self._build_payload(messages)
-
-        # ChatGPT Codex backend can take 60-180s on complex prompts when
-        # reasoning.summary=auto is enabled — the model spends time on the
-        # reasoning trace before emitting tokens. The previous hardcoded 60s
-        # was too tight: prompts with non-trivial BC topology (e.g. a 2-inlet
-        # elbow channel) deterministically exceeded it on gpt-5.5, raising
-        # `HTTPSConnectionPool ... Read timed out. (read timeout=60)` and
-        # failing the workflow. Allow operator override via env var.
         timeout = int(os.environ.get("FOAMAGENT_HTTP_TIMEOUT", "300"))
-        r = requests.post(url, headers=headers, json=payload, timeout=timeout, stream=bool(self._stream))
-
-        # If we get an error, surface the response body to aid debugging.
-        if not r.ok:
+        response = requests.post(
+            url,
+            headers=self._response_headers(),
+            json=payload,
+            timeout=timeout,
+            stream=bool(self._stream),
+        )
+        if not response.ok:
             try:
-                detail = r.text[:2000]
-            except Exception:
+                detail = response.text[:2000]
+            except requests.RequestException:
                 detail = ""
             raise requests.HTTPError(
-                f"HTTP {r.status_code} for {url}. Body: {detail}", response=r
+                f"HTTP {response.status_code} for {url}. Body: {detail}",
+                response=response,
             )
+        return response
 
-        if not self._stream:
-            data = r.json()
-            return self._Resp(self._extract_output_text(data))
-
-        # Streaming: accumulate text deltas.
+    def _stream_output_text(self, response: requests.Response) -> str:
+        """Accumulate supported Responses SSE text events with a safe fallback."""
         import json
 
         chunks: list[str] = []
-        for s in self._iter_sse_text(r):
+        for text in self._iter_sse_text(response):
             try:
-                j = json.loads(s)
-            except Exception:
+                event = json.loads(text)
+            except json.JSONDecodeError:
                 continue
-
-            # Codex backend streams OpenAI Responses-style events.
-            if isinstance(j, dict):
-                t = j.get("type")
-                if t == "response.output_text.delta" and isinstance(j.get("delta"), str):
-                    chunks.append(j["delta"])
+            if isinstance(event, dict):
+                event_type = event.get("type")
+                if event_type == "response.output_text.delta" and isinstance(event.get("delta"), str):
+                    chunks.append(event["delta"])
                     continue
-                if t == "response.output_text.done" and isinstance(j.get("text"), str):
-                    # Some clients rely on done; we already collected deltas but keep as fallback.
+                if event_type == "response.output_text.done" and isinstance(event.get("text"), str):
                     if not chunks:
-                        chunks.append(j["text"])
+                        chunks.append(event["text"])
                     continue
+            fallback = self._extract_output_text(event)
+            if fallback:
+                chunks.append(fallback)
+        return "".join(chunks).strip()
 
-            # Fallback: try generic extraction.
-            t2 = self._extract_output_text(j)
-            if t2:
-                chunks.append(t2)
-
-        return self._Resp("".join(chunks).strip())
+    def invoke(self, messages):
+        response = self._post_responses_request(messages)
+        if self._stream:
+            return self._Resp(self._stream_output_text(response))
+        return self._Resp(self._extract_output_text(response.json()))
 
 
 class LLMService:
     @staticmethod
-    def _load_codex_access_token_from_auth_json(auth_json_path: Path) -> str:
+    def _load_codex_oauth_from_auth_json(auth_json_path: Path) -> tuple[str, Optional[str]]:
         import json
 
         data = json.loads(auth_json_path.read_text(encoding="utf-8"))
@@ -349,9 +381,11 @@ class LLMService:
         # Common patterns we try:
         #   {"access_token": "..."}
         #   {"token": "..."}
+        #   {"tokens": {"access_token": "...", "account_id": "..."}}
         #   {"auth": {"access_token": "..."}}
         #   {"credentials": {"access_token": "..."}}
         candidates = []
+        account_id = None
 
         def maybe_add(v):
             if isinstance(v, str) and v.strip():
@@ -367,14 +401,21 @@ class LLMService:
                     maybe_add(v.get("access_token"))
                     maybe_add(v.get("token"))
 
+            tokens = data.get("tokens")
+            if isinstance(tokens, dict):
+                maybe_add(tokens.get("access_token"))
+                maybe_add(tokens.get("token"))
+                if isinstance(tokens.get("account_id"), str) and tokens["account_id"].strip():
+                    account_id = tokens["account_id"].strip()
+
         if not candidates:
             raise ValueError(
                 f"Could not find an access token in {auth_json_path}. "
-                "Expected keys like access_token/token/id_token."
+                "Expected keys like access_token/token or tokens.access_token."
             )
 
         # Prefer access_token-like strings first (we already appended in that order)
-        return candidates[0]
+        return candidates[0], account_id
 
     @staticmethod
     def _load_codex_oauth_from_clawdbot_auth_profiles(auth_profiles_path: Path) -> tuple[str, Optional[str]]:
@@ -451,18 +492,21 @@ class LLMService:
 
             # Codex CLI cache
             if p.name == "auth.json":
-                return self._load_codex_access_token_from_auth_json(p), None
+                return self._load_codex_oauth_from_auth_json(p)
 
             # Clawdbot cache
             if p.name == "auth-profiles.json":
                 return self._load_codex_oauth_from_clawdbot_auth_profiles(p)
 
         raise FileNotFoundError(
-            "Could not find a Codex/ChatGPT OAuth cache. Looked for: "
+            "model_provider='openai-codex' requires a Codex/ChatGPT OAuth cache. "
+            "Looked for: "
             + ", ".join(str(x) for x in candidates)
             + ". "
             "If you used the Codex CLI, run `codex login` and ensure file-based credential storage. "
-            "If you used Clawdbot, make sure you completed OpenAI Codex OAuth in onboarding."
+            "If you used Clawdbot, make sure you completed OpenAI Codex OAuth in onboarding. "
+            "To use an OpenAI Platform API key instead, set "
+            "FOAMAGENT_MODEL_PROVIDER=openai along with OPENAI_API_KEY."
         )
 
     def __init__(self, config: object):
@@ -510,7 +554,7 @@ class LLMService:
             instructions_path = Path(__file__).resolve().parent / "codex_instructions_default.txt"
             try:
                 instructions = instructions_path.read_text(encoding="utf-8")
-            except Exception:
+            except OSError:
                 instructions = "You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer."
 
             self.llm = _CodexResponsesWrapper(
@@ -524,7 +568,7 @@ class LLMService:
             )
         elif self.model_provider.lower() == "ollama":
             try:
-                response = requests.get("http://localhost:11434/api/version", timeout=2)
+                requests.get("http://localhost:11434/api/version", timeout=2)
                 # If request successful, service is running
             except requests.exceptions.RequestException:
                 print("Ollama is not running, starting it...")
@@ -618,6 +662,166 @@ class LLMService:
         
         return retry_count
 
+    @staticmethod
+    def _is_retryable_transport_error(error: Exception) -> bool:
+        """Recognise short-lived network failures from an LLM provider.
+
+        Only connection, timeout, TLS and proxy transport errors are retried.
+        HTTP response errors (for example authentication or invalid-request
+        errors) are deliberately left to the caller because retrying them
+        cannot make a malformed request valid.
+        """
+        return isinstance(
+            error,
+            (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                requests.exceptions.SSLError,
+            ),
+        )
+
+    def _handle_transport_retry(
+        self,
+        error: Exception,
+        retry_count: int,
+        max_retries: int,
+    ) -> Optional[int]:
+        """Retry a transient LLM transport error with bounded backoff."""
+        retry_count += 1
+        self.retry_count += 1
+        if retry_count > max_retries:
+            print(f"Maximum transport retries ({max_retries}) exceeded: {error}")
+            return None
+
+        delay = min(8.0, 1.0 * (2 ** (retry_count - 1)))
+        print(
+            "Transient LLM transport error; retrying in "
+            f"{delay:.1f} seconds (attempt {retry_count}/{max_retries}): {error}"
+        )
+        time.sleep(delay)
+        return retry_count
+
+    @staticmethod
+    def _is_retryable_structured_response_error(error: Exception) -> bool:
+        """Recognise transient empty/truncated structured-output responses.
+
+        This deliberately does not retry arbitrary Pydantic validation errors:
+        those usually indicate that the prompt or schema needs a real repair.
+        It covers only the two failures emitted by the local structured-output
+        wrapper before any JSON has been received.
+        """
+        message = str(error).casefold()
+        return (
+            "empty response; expected json" in message
+            or "could not find a json object in response" in message
+        )
+
+    def _handle_structured_response_retry(
+        self,
+        error: Exception,
+        retry_count: int,
+        max_retries: int,
+    ) -> Optional[int]:
+        """Retry a transient empty structured response with bounded backoff."""
+        retry_count += 1
+        self.retry_count += 1
+        if retry_count > max_retries:
+            print(
+                "Maximum structured-response retries "
+                f"({max_retries}) exceeded: {error}"
+            )
+            return None
+
+        delay = min(4.0, 0.5 * (2 ** (retry_count - 1)))
+        print(
+            "Structured LLM response was empty or truncated; retrying in "
+            f"{delay:.1f} seconds (attempt {retry_count}/{max_retries})."
+        )
+        time.sleep(delay)
+        return retry_count
+
+    @staticmethod
+    def _messages_for_request(user_prompt: str, system_prompt: Optional[str]) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": user_prompt})
+        return messages
+
+    def _invoke_deepseek_structured(
+        self,
+        messages: list[dict[str, str]],
+        schema: Type[BaseModel],
+    ) -> BaseModel:
+        """Use the JSON prompt fallback required by DeepSeek thinking mode."""
+        json_instruction = (
+            "Return ONLY valid JSON (no markdown, no extra text) matching this schema:\n"
+            + str(schema.model_json_schema())
+        )
+        raw_response = self.llm.invoke(
+            [*messages, {"role": "user", "content": json_instruction}]
+        )
+        text = raw_response.content.strip()
+        if text.startswith("```"):
+            text = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", text)
+            text = re.sub(r"\n?```\s*$", "", text).strip()
+        return schema.model_validate_json(text)
+
+    def _invoke_model(
+        self,
+        messages: list[dict[str, str]],
+        pydantic_obj: Optional[Type[BaseModel]],
+    ) -> Any:
+        """Call the configured provider, including its structured-output variant."""
+        if pydantic_obj is None:
+            return self.llm.invoke(messages).content
+        if self.model_provider.lower() == "deepseek":
+            return self._invoke_deepseek_structured(messages, pydantic_obj)
+        return self.llm.with_structured_output(pydantic_obj).invoke(messages)
+
+    def _record_successful_response(self, response: Any, prompt_tokens: int) -> None:
+        completion_tokens = self.llm.get_num_tokens(str(response))
+        self.total_prompt_tokens += prompt_tokens
+        self.total_completion_tokens += completion_tokens
+        self.total_tokens += prompt_tokens + completion_tokens
+
+    def _retry_counts_after_error(
+        self,
+        error: Exception,
+        *,
+        retry_count: int,
+        transport_retry_count: int,
+        structured_retry_count: int,
+        max_retries: int,
+        has_structured_output: bool,
+    ) -> tuple[int, int, int]:
+        """Sleep and return updated counters for retryable failures, else raise."""
+        if self._is_throttling_error(error):
+            updated = self._handle_throttling_retry(error, retry_count, max_retries)
+            if updated is not None:
+                return updated, transport_retry_count, structured_retry_count
+            self.failed_calls += 1
+            raise RuntimeError(
+                f"Maximum retries ({max_retries}) exceeded for throttling error: {error}"
+            ) from error
+        if self._is_retryable_transport_error(error):
+            updated = self._handle_transport_retry(error, transport_retry_count, 3)
+            if updated is not None:
+                return retry_count, updated, structured_retry_count
+            self.failed_calls += 1
+            raise error
+        if has_structured_output and self._is_retryable_structured_response_error(error):
+            updated = self._handle_structured_response_retry(error, structured_retry_count, 3)
+            if updated is not None:
+                return retry_count, transport_retry_count, updated
+            self.failed_calls += 1
+            raise error
+        print(f"Non-throttling error occurred: {error}.")
+        if isinstance(error, ClientError):
+            print(error.response)
+        self.failed_calls += 1
+        raise error
+
     def invoke(self,
               user_prompt: str, 
               system_prompt: Optional[str] = None, 
@@ -637,76 +841,27 @@ class LLMService:
         """
         self.total_calls += 1
         
-        messages = []
-        if system_prompt:
-            messages.append({"role": "system", "content": system_prompt})
-        messages.append({"role": "user", "content": user_prompt})
-        
-        # Calculate prompt tokens
-        prompt_tokens = 0
-        for message in messages:
-            prompt_tokens += self.llm.get_num_tokens(message["content"])
-        
+        messages = self._messages_for_request(user_prompt, system_prompt)
+        prompt_tokens = sum(self.llm.get_num_tokens(message["content"]) for message in messages)
         retry_count = 0
+        transport_retry_count = 0
+        structured_response_retry_count = 0
         while True:
             try:
-                if pydantic_obj:
-                    if self.model_provider.lower() == "deepseek":
-                        # DeepSeek thinking mode does not support response_format,
-                        # so with_structured_output fails. Use JSON prompt fallback.
-                        schema = pydantic_obj.model_json_schema()
-                        json_instruction = (
-                            "Return ONLY valid JSON (no markdown, no extra text) matching this schema:\n"
-                            + str(schema)
-                        )
-                        json_messages = list(messages)
-                        json_messages.append({"role": "user", "content": json_instruction})
-                        raw_response = self.llm.invoke(json_messages)
-                        raw_text = raw_response.content
-                        # Strip markdown fences if present
-                        t = raw_text.strip()
-                        if t.startswith("```"):
-                            t = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", t)
-                            t = re.sub(r"\n?```\s*$", "", t).strip()
-                        response = pydantic_obj.model_validate_json(t)
-                    else:
-                        structured_llm = self.llm.with_structured_output(pydantic_obj)
-                        response = structured_llm.invoke(messages)
-                else:
-                    response = self.llm.invoke(messages)
-                    response = response.content
-
-                # Calculate completion tokens
-                response_content = str(response)
-                completion_tokens = self.llm.get_num_tokens(response_content)
-                total_tokens = prompt_tokens + completion_tokens
-                
-                # Update statistics
-                self.total_prompt_tokens += prompt_tokens
-                self.total_completion_tokens += completion_tokens
-                self.total_tokens += total_tokens
-                
+                response = self._invoke_model(messages, pydantic_obj)
+                self._record_successful_response(response, prompt_tokens)
                 return response
-                
-            except Exception as e:
-                if self._is_throttling_error(e):
-                    print(f"ThrottlingException occurred: {str(e)}.")
-                    print(f"Retrying: {retry_count + 1}/{max_retries}")
-                    retry_count = self._handle_throttling_retry(e, retry_count, max_retries)
-                    if retry_count is None:
-                        # Max retries exceeded
-                        self.failed_calls += 1
-                        raise Exception(f"Maximum retries ({max_retries}) exceeded for throttling error: {str(e)}")
-                    continue  # Retry the request
-                else:
-                    print(f"Non-throttling error occurred: {str(e)}.")
-
-                    # Non-throttling error: log and raise
-                    print(f"Error occurred in LLM service: {str(e)}")
-                    if isinstance(e, ClientError):
-                        print(e.response)
-                    self.failed_calls += 1
-                    raise e
+            except Exception as error:  # noqa: BLE001 - provider exceptions have no common base class
+                retry_count, transport_retry_count, structured_response_retry_count = (
+                    self._retry_counts_after_error(
+                        error,
+                        retry_count=retry_count,
+                        transport_retry_count=transport_retry_count,
+                        structured_retry_count=structured_response_retry_count,
+                        max_retries=max_retries,
+                        has_structured_output=pydantic_obj is not None,
+                    )
+                )
     
     def get_statistics(self) -> dict:
         """
@@ -790,6 +945,20 @@ class GraphState(TypedDict):
     cluster_info: Optional[dict]
     slurm_script_path: Optional[str]
     termination_reason: Optional[str]
+    # Existing-case import branch.  These fields keep the imported source and
+    # its controlled retry history separate from generated-case dictionaries.
+    workflow_mode: str
+    execution_policy: str
+    repair_policy: str
+    case_import_path: Optional[str]
+    case_import_subdir: Optional[str]
+    case_import_manifest: Optional[Any]
+    case_import_original_dir: Optional[str]
+    case_import_report_dir: Optional[str]
+    case_import_attempts: Optional[List[dict]]
+    case_import_overrides: Optional[Dict[str, bytes]]
+    case_import_error_fingerprints: Optional[List[str]]
+    case_import_status: Optional[str]
 
 def tokenize(text: str) -> str:
     # Replace underscores with spaces
@@ -843,7 +1012,7 @@ def remove_numeric_folders(case_dir: str) -> None:
                 try:
                     shutil.rmtree(item_path)
                     print(f"Removed numeric folder: {item_path}")
-                except Exception as e:
+                except OSError as e:
                     print(f"Error removing folder {item_path}: {str(e)}")
             except ValueError:
                 # Not a numeric value, so we keep this folder
@@ -942,14 +1111,28 @@ def read_case_foamfiles(case_dir: str, dir_structure: Optional[Dict[str, List[st
                 ))
             except UnicodeDecodeError:
                 print(f"Warning: Skipping file due to encoding error: {file_path}")
-            except Exception as e:
+            except OSError as e:
                 print(f"Warning: Error reading file {file_path}: {e}")
     
     return FoamPydantic(list_foamfile=foamfile_list)
 
-def run_command(script_path: str, out_file: str, err_file: str, working_dir: str, max_time_limit: int) -> None:
+def run_command(
+    script_path: str,
+    out_file: str,
+    err_file: str,
+    working_dir: str,
+    max_time_limit: int,
+) -> Dict[str, Any]:
+    """Run an OpenFOAM shell script and return its process outcome.
+
+    Existing callers may continue to ignore the return value.  Callers which
+    need reliable execution status can inspect ``returncode`` and
+    ``timed_out`` instead of inferring success solely from log contents.
+    """
     print(f"Executing script {script_path} in {working_dir}")
-    os.chmod(script_path, 0o777)
+    script = Path(script_path).expanduser().resolve()
+    if not script.is_file():
+        raise FileNotFoundError(f"OpenFOAM script does not exist: {script}")
     openfoam_dir = os.getenv("WM_PROJECT_DIR")
     if not openfoam_dir:
         raise RuntimeError(
@@ -957,42 +1140,102 @@ def run_command(script_path: str, out_file: str, err_file: str, working_dir: str
             "(e.g., source env/common.sh and env/foamagent.sh)."
         )
 
-    bashrc_path = os.path.join(openfoam_dir, "etc", "bashrc")
-    if not os.path.exists(bashrc_path):
+    bashrc_path = Path(openfoam_dir).expanduser() / "etc" / "bashrc"
+    if not bashrc_path.is_file():
         raise RuntimeError(f"OpenFOAM bashrc not found at: {bashrc_path}")
 
-    command = f"source {bashrc_path} && bash {os.path.abspath(script_path)}"
+    # Never interpolate paths into shell source.  Script and bashrc paths can
+    # legitimately contain spaces and, for imported cases, originate outside
+    # Foam-Agent.  Passing them as positional parameters prevents shell
+    # metacharacters from being interpreted as code.
+    shell_command = 'source "$1" && exec bash "$2"'
+
+    timed_out = False
 
     with open(out_file, 'w') as out, open(err_file, 'w') as err:
         process = subprocess.Popen(
-            ['bash', "-c", command],
+            ["bash", "-c", shell_command, "foamagent-runner", str(bashrc_path), str(script)],
             cwd=working_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            # Stream child output directly to disk.  ``communicate()`` buffers
+            # all solver output in memory and can OOM on a legitimate long CFD
+            # run with verbose residual logs.
+            stdout=out,
+            stderr=err,
             stdin=subprocess.DEVNULL,
-            text=True,
             start_new_session=True,
         )
 
         try:
-            stdout, stderr = process.communicate(timeout=max_time_limit)
-            out.write(stdout)
-            err.write(stderr)
+            process.wait(timeout=max_time_limit)
         except subprocess.TimeoutExpired:
-            os.killpg(os.getpgid(process.pid), signal.SIGKILL) 
-            
-            stdout, stderr = process.communicate()
+            timed_out = True
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                # The process can exit between ``wait`` timing out and the
+                # group lookup; its return code is still collected below.
+                pass
+            process.wait()
             timeout_message = (
-                "OpenFOAM execution took too long. "
-                "This case, if set up right, does not require such large execution times.\n"
+                f"OpenFOAM execution exceeded the {max_time_limit} second timeout.\n"
             )
-            out.write(timeout_message + stdout)
-            err.write(timeout_message + stderr)
+            out.write(timeout_message)
+            err.write(timeout_message)
             print(f"Execution timed out: {script_path}")
 
-    
-
     print(f"Executed script {script_path}")
+    return {
+        "returncode": process.returncode,
+        "timed_out": timed_out,
+    }
+
+_EXPLICIT_FOAM_ERROR_RE = re.compile(r"ERROR:(.*)", re.DOTALL)
+_SEMANTIC_FOAM_FAILURES = (
+    (
+        re.compile(r"Failed\s+\d+\s+mesh\s+checks?", re.IGNORECASE),
+        "checkMesh reported failed mesh checks",
+    ),
+)
+_FOAM_END_RE = re.compile(r"^\s*End\s*$", re.MULTILINE)
+
+
+def _read_foam_log(directory: str, file_name: str) -> tuple[str | None, dict | None]:
+    filepath = os.path.join(directory, file_name)
+    try:
+        with open(filepath, encoding="utf-8") as log_file:
+            return log_file.read(), None
+    except OSError:
+        return None, {"file": file_name, "error_content": f"Could not read log file: {filepath}"}
+
+
+def _foam_log_failure(file_name: str, content: str) -> dict | None:
+    """Return an explicit or semantic OpenFOAM error found in one log."""
+    for pattern, reason in _SEMANTIC_FOAM_FAILURES:
+        match = pattern.search(content)
+        if match:
+            line = content[match.start() :].splitlines()[0].strip()
+            return {
+                "file": file_name,
+                "error_content": f"Semantic simulation failure: {reason}. OpenFOAM reported: {line}",
+            }
+    match = _EXPLICIT_FOAM_ERROR_RE.search(content)
+    if match:
+        return {"file": file_name, "error_content": match.group(0).strip()}
+    return None
+
+
+def _unfinished_foam_log(file_name: str, content: str) -> dict | None:
+    if _FOAM_END_RE.search(content):
+        return None
+    last_lines = "\n".join(content.strip().split("\n")[-30:])
+    return {
+        "file": file_name,
+        "error_content": (
+            "Solver did not complete (no 'End' marker found). "
+            f"Last 30 lines:\n{last_lines}"
+        ),
+    }
+
 
 def check_foam_errors(directory: str) -> list:
     """Check OpenFOAM log files for errors.
@@ -1003,49 +1246,28 @@ def check_foam_errors(directory: str) -> list:
     completion.  Any log missing ``End`` is reported with the last 30 lines
     as error context so the caller can diagnose the crash.
     """
-    error_logs = []
-    log_contents = {}  # filename -> content
-
-    # DOTALL mode allows '.' to match newline characters
-    pattern = re.compile(r"ERROR:(.*)", re.DOTALL)
-
-    for file in os.listdir(directory):
-        if file.startswith("log"):
-            filepath = os.path.join(directory, file)
-            try:
-                with open(filepath, 'r') as f:
-                    content = f.read()
-            except (IOError, OSError):
-                error_logs.append({"file": file, "error_content": f"Could not read log file: {filepath}"})
-                continue
-
-            log_contents[file] = content
-
-            match = pattern.search(content)
-            if match:
-                error_content = match.group(0).strip()
-                error_logs.append({"file": file, "error_content": error_content})
-            elif "error" in content.lower():
-                print(f"Warning: file {file} contains 'error' but does not match expected format.")
-
-    # Safety-net: if no explicit ERROR was found, check for missing 'End' marker
-    # Check EACH log individually – a successful blockMesh should not mask a
-    # crashed solver (e.g. pimpleFoam).
-    if not error_logs and log_contents:
-        end_pattern = re.compile(r"^\s*End\s*$", re.MULTILINE)
-
-        for file, content in log_contents.items():
-            if not end_pattern.search(content):
-                last_lines = "\n".join(content.strip().split("\n")[-30:])
-                error_logs.append({
-                    "file": file,
-                    "error_content": (
-                        f"Solver did not complete (no 'End' marker found). "
-                        f"Last 30 lines:\n{last_lines}"
-                    ),
-                })
-
-    return error_logs
+    error_logs: list[dict] = []
+    log_contents: dict[str, str] = {}
+    for file_name in os.listdir(directory):
+        if not file_name.startswith("log"):
+            continue
+        content, read_error = _read_foam_log(directory, file_name)
+        if read_error:
+            error_logs.append(read_error)
+            continue
+        if content is None:
+            continue
+        log_contents[file_name] = content
+        failure = _foam_log_failure(file_name, content)
+        if failure:
+            error_logs.append(failure)
+    if error_logs or not log_contents:
+        return error_logs
+    return [
+        failure
+        for file_name, content in log_contents.items()
+        if (failure := _unfinished_foam_log(file_name, content)) is not None
+    ]
 
 def extract_commands_from_allrun_out(out_file: str) -> list:
     commands = []
@@ -1115,23 +1337,35 @@ def find_input_file(case_dir: str, command: str) -> str:
                 return os.path.join(root, file)
     return ""
 
-def retrieve_faiss(database_name: str, query: str, topk: int = 1) -> dict:
+def retrieve_faiss(
+    database_name: str,
+    query: str,
+    topk: int = 1,
+    *,
+    config: Optional[Config] = None,
+) -> dict:
     """
-    Retrieve a similar case from a FAISS database.
+    Retrieve a similar case from a FAISS database selected by ``config``.
+
+    Omitting ``config`` retains the environment/default-backed behaviour used
+    by legacy callers.  Supplying it is required when one process serves
+    multiple configured workflows, because each embedding model needs its own
+    compatible FAISS index and query vector.
     """
 
-    if database_name not in FAISS_DB_CACHE:
+    dbs = _ensure_faiss_dbs_loaded(config)
+    if database_name not in dbs:
         raise ValueError(f"Database '{database_name}' is not loaded.")
 
     # Tokenize the query
     query = tokenize(query)
 
-    vectordb = FAISS_DB_CACHE[database_name]
+    vectordb = dbs[database_name]
     try:
         docs_and_scores = vectordb.similarity_search_with_score(query, k=topk)
         docs = [d for d, _ in docs_and_scores]
         scores = [s for _, s in docs_and_scores]
-    except Exception:
+    except (AttributeError, NotImplementedError):
         docs = vectordb.similarity_search(query, k=topk)
         scores = [None] * len(docs)
 

--- a/tests/test_case_import.py
+++ b/tests/test_case_import.py
@@ -1,0 +1,230 @@
+"""Tests for the Foundation-v10-only existing-case import workflow."""
+
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+import zipfile
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from services import case_import  # noqa: E402
+from services.case_import_allrun import parse_allrun  # noqa: E402
+from services.case_import import (  # noqa: E402
+    CaseImportError,
+    apply_safe_repairs,
+    import_case,
+)
+
+
+def _foundation_header() -> str:
+    return """/*--------------------------------*- C++ -*----------------------------------*\\
+| OpenFOAM: The Open Source CFD Toolbox
+| Website:  https://openfoam.org
+| Version:  10
+\\*---------------------------------------------------------------------------*/
+"""
+
+
+def _write_case(root: Path, *, allrun: str | None = None, esi: bool = False) -> Path:
+    (root / "system").mkdir(parents=True)
+    (root / "constant").mkdir()
+    header = _foundation_header()
+    if esi:
+        header = header.replace("https://openfoam.org", "www.openfoam.com").replace(
+            "Version:  10", "Version:  v2312"
+        )
+    (root / "system" / "controlDict").write_text(
+        header
+        + """FoamFile
+{
+    format ascii;
+    class dictionary;
+    object controlDict;
+}
+application icoFoam;
+startTime 0;
+endTime 2;
+""",
+        encoding="utf-8",
+    )
+    (root / "system" / "blockMeshDict").write_text(
+        header + "FoamFile { object blockMeshDict; }\n",
+        encoding="utf-8",
+    )
+    if allrun is not None:
+        (root / "Allrun").write_text(allrun, encoding="utf-8")
+    return root
+
+
+def test_import_preserves_original_and_inserts_mesh_gate(tmp_path: Path) -> None:
+    source = _write_case(
+        tmp_path / "source",
+        allrun="""#!/bin/sh
+cd ${0%/*} || exit 1
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+application=$(getApplication)
+runApplication blockMesh
+runApplication $application
+""",
+    )
+
+    manifest = import_case(source, tmp_path / "import-output")
+
+    assert manifest.platform == "foundation-v10"
+    assert [step.command for step in manifest.execution_plan] == [
+        "blockMesh",
+        "checkMesh",
+        "icoFoam",
+    ]
+    assert (tmp_path / "import-output" / "original" / "system" / "controlDict").read_text(
+        encoding="utf-8"
+    ) == (source / "system" / "controlDict").read_text(encoding="utf-8")
+    original_control = tmp_path / "import-output" / "original" / "system" / "controlDict"
+    assert not (original_control.stat().st_mode & stat.S_IWUSR)
+    assert manifest.original_hashes["system/controlDict"]
+
+
+def test_import_rejects_esi_case_without_running_it(tmp_path: Path) -> None:
+    source = _write_case(tmp_path / "esi-source", esi=True)
+
+    manifest = import_case(source, tmp_path / "import-output")
+
+    assert not manifest.supported
+    assert manifest.platform == "esi"
+    assert any("Only Foundation OpenFOAM v10" in issue for issue in manifest.blocking_issues)
+
+
+def test_import_overwrite_clears_output_contents_without_removing_root(
+    tmp_path: Path,
+) -> None:
+    source = _write_case(tmp_path / "source")
+    output = tmp_path / "import-output"
+    # Only a directory previously created by Foam-Agent may be cleared.  This
+    # makes --overwrite_output safe if a caller accidentally names a valuable
+    # existing directory.
+    import_case(source, output)
+    stale_file = output / "previous-result"
+    stale_file.write_text("stale", encoding="utf-8")
+
+    manifest = import_case(source, output, overwrite=True)
+
+    assert output.is_dir()
+    assert not stale_file.exists()
+    assert (output / "original" / "system" / "controlDict").is_file()
+    assert manifest.output_root == str(output.resolve())
+
+
+def test_import_overwrite_rejects_unowned_output_directory(tmp_path: Path) -> None:
+    source = _write_case(tmp_path / "source")
+    output = tmp_path / "unowned-output"
+    output.mkdir()
+    sentinel = output / "do-not-delete"
+    sentinel.write_text("important", encoding="utf-8")
+
+    with pytest.raises(CaseImportError, match="unowned output directory"):
+        import_case(source, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important"
+
+
+def test_import_requires_case_subdir_for_multi_case_zip(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive-root"
+    _write_case(archive_root / "first")
+    _write_case(archive_root / "second")
+    archive = tmp_path / "cases.zip"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        for path in archive_root.rglob("*"):
+            if path.is_file():
+                zip_file.write(path, path.relative_to(archive_root))
+
+    with pytest.raises(CaseImportError, match="Multiple OpenFOAM cases"):
+        import_case(archive, tmp_path / "multi-output")
+
+    manifest = import_case(
+        archive,
+        tmp_path / "selected-output",
+        case_subdir="second",
+    )
+    assert manifest.case_root == "second"
+    assert manifest.application == "icoFoam"
+
+
+def test_safe_repair_changes_header_not_numbers(tmp_path: Path) -> None:
+    case = _write_case(tmp_path / "case")
+    control_dict = case / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8").replace(
+            "object controlDict;", "object incorrectName;"
+        ),
+        encoding="utf-8",
+    )
+
+    repairs = apply_safe_repairs(case, [{"error_content": "FoamFile object mismatch"}])
+
+    repaired = control_dict.read_text(encoding="utf-8")
+    assert "object controlDict;" in repaired
+    assert "endTime 2;" in repaired
+    assert any(repair["status"] == "applied" for repair in repairs)
+
+
+def test_import_run_retries_only_after_a_safe_non_numeric_repair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write_case(tmp_path / "source")
+    control_dict = source / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8").replace(
+            "object controlDict;", "object incorrectName;"
+        ),
+        encoding="utf-8",
+    )
+    calls = 0
+
+    def simulated_execution(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return [{"error_content": "FoamFile object mismatch"}] if calls == 1 else []
+
+    monkeypatch.setattr(case_import, "execute_imported_case", simulated_execution)
+    result = case_import.run_imported_case(
+        source,
+        tmp_path / "import-output",
+        max_repairs=1,
+    )
+
+    assert result.status == "success"
+    assert calls == 2
+    assert "endTime 2;" in (tmp_path / "import-output" / "work" / "system" / "controlDict").read_text(
+        encoding="utf-8"
+    )
+    assert any(
+        repair["status"] == "applied"
+        for repair in result.attempts[0]["repairs"]
+    )
+
+
+def test_allrun_parser_rejects_arbitrary_shell_setup() -> None:
+    with pytest.raises(CaseImportError, match="Unsupported shell setup"):
+        parse_allrun(
+            ". ./untrusted-helper.sh\nrunApplication icoFoam\n",
+            "icoFoam",
+        )
+
+
+def test_allrun_parser_prevents_writes_outside_work_copy() -> None:
+    # The importer now rejects every -case override, not merely absolute
+    # paths: a nested case would otherwise bypass the selected case's
+    # platform and preflight validation.
+    with pytest.raises(CaseImportError, match="case arguments|Absolute paths"):
+        parse_allrun(
+            "runApplication blockMesh -case=/tmp/another-case\n"
+            "runApplication icoFoam\n",
+            "icoFoam",
+        )

--- a/tests/test_case_import_hardening.py
+++ b/tests/test_case_import_hardening.py
@@ -1,0 +1,702 @@
+"""Security and boundary regression tests for existing-case imports.
+
+These tests deliberately exercise inputs that should fail *before* an import
+output is modified.  A case archive is untrusted input, and an invalid source
+must never turn ``--overwrite_output`` into a way to erase a user's prior
+results or the source being imported.
+"""
+
+from __future__ import annotations
+
+import stat
+import os
+import subprocess
+import sys
+from pathlib import Path
+import zipfile
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from services import case_import  # noqa: E402
+from services import case_import_source  # noqa: E402
+from services.case_import_allrun import (  # noqa: E402
+    ensure_mesh_check,
+    parse_allrun,
+    render_controlled_allrun,
+)
+from services.case_import import (  # noqa: E402
+    CaseImportError,
+    ExecutionStep,
+    _run_imported_manifest,
+    apply_safe_repairs,
+    import_case,
+)
+from services.case_import_repairs import numeric_snapshot  # noqa: E402
+from services.output_safety import prepare_output_directory  # noqa: E402
+
+
+def _foundation_header() -> str:
+    return """/*--------------------------------*- C++ -*----------------------------------*\\
+| OpenFOAM: The Open Source CFD Toolbox
+| Website:  https://openfoam.org
+| Version:  10
+\\*---------------------------------------------------------------------------*/
+"""
+
+
+def _write_foundation_case(
+    root: Path,
+    *,
+    allrun: str | None = None,
+    with_block_mesh: bool = True,
+    with_poly_mesh: bool = False,
+) -> Path:
+    """Create the smallest valid Foundation-v10 import fixture."""
+    (root / "system").mkdir(parents=True)
+    (root / "constant").mkdir()
+    (root / "system" / "controlDict").write_text(
+        _foundation_header()
+        + """FoamFile
+{
+    format ascii;
+    class dictionary;
+    object controlDict;
+}
+application icoFoam;
+startTime 0;
+endTime 2;
+""",
+        encoding="utf-8",
+    )
+    if with_block_mesh:
+        (root / "system" / "blockMeshDict").write_text(
+            _foundation_header() + "FoamFile { object blockMeshDict; }\n",
+            encoding="utf-8",
+        )
+    if with_poly_mesh:
+        (root / "constant" / "polyMesh").mkdir()
+        (root / "constant" / "polyMesh" / "boundary").write_text(
+            "0\n(\n)\n", encoding="utf-8"
+        )
+    if allrun is not None:
+        (root / "Allrun").write_text(allrun, encoding="utf-8")
+    return root
+
+
+def _archive_tree(source: Path, archive: Path, *, prefix: str = "") -> Path:
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        for path in sorted(source.rglob("*")):
+            if path.is_file():
+                name = path.relative_to(source).as_posix()
+                zip_file.write(path, f"{prefix}{name}")
+    return archive
+
+
+def _nonempty_output(root: Path) -> tuple[Path, Path]:
+    output = prepare_output_directory(root / "output", overwrite=False)
+    # Exercise the dangerous branch: an owned output is the only kind that
+    # ``--overwrite_output`` is allowed to clear.  Invalid input must still
+    # leave its existing contents intact.
+    sentinel = output / "do-not-delete.txt"
+    sentinel.write_text("important prior result", encoding="utf-8")
+    return output, sentinel
+
+
+@pytest.mark.parametrize("link_kind", ["file", "directory"])
+def test_invalid_symlink_source_does_not_clear_existing_output(
+    tmp_path: Path,
+    link_kind: str,
+) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    external = tmp_path / "external"
+    if link_kind == "file":
+        external.write_text("outside", encoding="utf-8")
+    else:
+        external.mkdir()
+    (source / "constant" / "untrusted-link").symlink_to(
+        external, target_is_directory=link_kind == "directory"
+    )
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="[Ss]ymbolic links"):
+        import_case(source, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+    assert external.exists()
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../escape.txt",
+        r"..\escape.txt",
+        "/absolute/escape.txt",
+        r"\absolute\escape.txt",
+        r"C:\absolute\escape.txt",
+        "C:/absolute/escape.txt",
+    ],
+)
+def test_unsafe_zip_member_is_rejected_before_existing_output_is_cleared(
+    tmp_path: Path,
+    member_name: str,
+) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    archive = _archive_tree(source, tmp_path / "case.zip")
+    with zipfile.ZipFile(archive, "a") as zip_file:
+        zip_file.writestr(member_name, "must never be extracted")
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="ZIP entry"):
+        import_case(archive, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_zip_symlink_is_rejected_before_existing_output_is_cleared(tmp_path: Path) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    archive = _archive_tree(source, tmp_path / "case.zip")
+    link_info = zipfile.ZipInfo("constant/untrusted-link")
+    link_info.create_system = 3
+    link_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(archive, "a") as zip_file:
+        zip_file.writestr(link_info, "../../outside")
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="ZIP symbolic links"):
+        import_case(archive, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+def test_archive_member_count_limit_is_checked_before_existing_output_is_cleared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = tmp_path / "too-many-members.zip"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("one", "1")
+        zip_file.writestr("two", "2")
+    monkeypatch.setattr(case_import_source, "MAX_ARCHIVE_FILES", 1)
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="ZIP contains 2 entries"):
+        import_case(archive, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+def test_archive_uncompressed_byte_limit_is_checked_before_output_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = tmp_path / "too-large.zip"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("payload", "12")
+    monkeypatch.setattr(case_import_source, "MAX_ARCHIVE_BYTES", 1)
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="uncompressed size exceeds"):
+        import_case(archive, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+def test_directory_file_limit_is_checked_before_existing_output_is_cleared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    monkeypatch.setattr(case_import_source, "MAX_ARCHIVE_FILES", 1)
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="import safety limit"):
+        import_case(source, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+def test_reserved_foamagent_directory_is_rejected_before_output_mutation(tmp_path: Path) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    (source / ".foamagent").mkdir()
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="reserved .foamagent"):
+        import_case(source, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+def test_non_case_directory_does_not_clear_existing_owned_output(tmp_path: Path) -> None:
+    source = tmp_path / "not-a-case"
+    source.mkdir()
+    (source / "notes.txt").write_text("not an OpenFOAM case", encoding="utf-8")
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="No system/controlDict"):
+        import_case(source, output, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+@pytest.mark.parametrize("subdir", ["../source", "/tmp", r"..\\source"])
+def test_invalid_case_subdir_does_not_clear_existing_output(
+    tmp_path: Path,
+    subdir: str,
+) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    output, sentinel = _nonempty_output(tmp_path)
+
+    with pytest.raises(CaseImportError, match="case_subdir"):
+        import_case(source, output, case_subdir=subdir, overwrite=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "important prior result"
+
+
+def test_output_inside_source_is_rejected_without_touching_source(tmp_path: Path) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    marker = source / "keep-me.txt"
+    marker.write_text("case input", encoding="utf-8")
+
+    with pytest.raises(CaseImportError, match="inside the source"):
+        import_case(source, source / "foamagent-output", overwrite=True)
+
+    assert marker.read_text(encoding="utf-8") == "case input"
+
+
+def test_output_containing_directory_source_is_rejected_before_overwrite(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    source = _write_foundation_case(output / "source")
+    marker = source / "keep-me.txt"
+    marker.write_text("case input", encoding="utf-8")
+    (output / "prior-result.txt").write_text("prior result", encoding="utf-8")
+
+    with pytest.raises(CaseImportError):
+        import_case(source, output, overwrite=True)
+
+    assert marker.read_text(encoding="utf-8") == "case input"
+    assert (output / "prior-result.txt").read_text(encoding="utf-8") == "prior result"
+
+
+def test_output_containing_zip_source_is_rejected_before_overwrite(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    source = _write_foundation_case(tmp_path / "source")
+    archive = _archive_tree(source, output / "case.zip")
+    (output / "prior-result.txt").write_text("prior result", encoding="utf-8")
+
+    with pytest.raises(CaseImportError):
+        import_case(archive, output, overwrite=True)
+
+    assert archive.is_file()
+    assert (output / "prior-result.txt").read_text(encoding="utf-8") == "prior result"
+
+
+def test_overwrite_unlinks_output_symlink_without_deleting_its_target(tmp_path: Path) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    output = tmp_path / "output"
+    prepare_output_directory(output, overwrite=False)
+    external = tmp_path / "external-result"
+    external.mkdir()
+    target_file = external / "preserve.txt"
+    target_file.write_text("outside output", encoding="utf-8")
+    (output / "external-link").symlink_to(external, target_is_directory=True)
+
+    import_case(source, output, overwrite=True)
+
+    assert target_file.read_text(encoding="utf-8") == "outside output"
+    assert not (output / "external-link").exists()
+
+
+def test_output_path_symlink_is_rejected_without_touching_its_target(tmp_path: Path) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    target = tmp_path / "target"
+    target.mkdir()
+    sentinel = target / "preserve.txt"
+    sentinel.write_text("outside output", encoding="utf-8")
+    output_link = tmp_path / "output-link"
+    output_link.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(CaseImportError, match="symlink"):
+        import_case(source, output_link)
+
+    assert sentinel.read_text(encoding="utf-8") == "outside output"
+
+
+def test_output_path_through_symlinked_parent_is_rejected_without_touching_target(
+    tmp_path: Path,
+) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    target_parent = tmp_path / "real-parent"
+    target_parent.mkdir()
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(target_parent, target_is_directory=True)
+    output = linked_parent / "output"
+
+    with pytest.raises(CaseImportError, match="symlink"):
+        import_case(source, output)
+
+    assert not (target_parent / "output").exists()
+
+
+def test_initial_execution_makes_read_only_work_copy_writable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first controlled run must work even when the uploaded case is read-only."""
+    source = _write_foundation_case(tmp_path / "source")
+    source.chmod(0o555)
+    try:
+        manifest = import_case(source, tmp_path / "output")
+    finally:
+        # Let pytest remove the input fixture after the import has preserved
+        # its source permissions in the work copy.
+        source.chmod(0o755)
+
+    def successful_controlled_run(work_dir: Path, *_args: object, **_kwargs: object) -> list[object]:
+        (Path(work_dir) / ".foamagent").mkdir()
+        return []
+
+    monkeypatch.setattr(case_import, "execute_imported_case", successful_controlled_run)
+
+    result = _run_imported_manifest(manifest, timeout=1, max_repairs=0)
+
+    assert result.status == "success"
+    assert (Path(manifest.output_root) / "work").stat().st_mode & stat.S_IWUSR
+    assert not (
+        (Path(manifest.output_root) / "original" / "system").stat().st_mode
+        & stat.S_IWUSR
+    )
+
+
+def test_existing_poly_mesh_without_allrun_generates_check_then_solver(tmp_path: Path) -> None:
+    source = _write_foundation_case(
+        tmp_path / "source", with_block_mesh=False, with_poly_mesh=True
+    )
+
+    manifest = import_case(source, tmp_path / "output")
+
+    assert [step.command for step in manifest.execution_plan] == ["checkMesh", "icoFoam"]
+    assert all(step.origin == "generated_missing_allrun" for step in manifest.execution_plan)
+
+
+def test_missing_start_time_directory_blocks_synthesised_plan(tmp_path: Path) -> None:
+    """A startTime restart needs its matching field directory before execution."""
+    source = _write_foundation_case(tmp_path / "source")
+    control_dict = source / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8").replace(
+            "startTime 0;", "startFrom startTime;\nstartTime 0.5;"
+        ),
+        encoding="utf-8",
+    )
+    (source / "0").mkdir()
+
+    manifest = import_case(source, tmp_path / "output")
+
+    assert not manifest.supported
+    assert manifest.blocking_issues
+
+
+def test_mesh_gate_is_inserted_after_last_mesh_operation_and_before_solver() -> None:
+    steps = [
+        ExecutionStep("blockMesh"),
+        ExecutionStep("snappyHexMesh"),
+        ExecutionStep("icoFoam"),
+    ]
+
+    repaired = ensure_mesh_check(steps, "icoFoam")
+
+    assert [step.command for step in repaired] == [
+        "blockMesh",
+        "snappyHexMesh",
+        "checkMesh",
+        "icoFoam",
+    ]
+    assert repaired[2].origin == "foamagent_mesh_gate"
+
+
+def test_mesh_gate_does_not_accept_checkmesh_before_mesh_generation() -> None:
+    steps = [
+        ExecutionStep("checkMesh"),
+        ExecutionStep("blockMesh"),
+        ExecutionStep("icoFoam"),
+    ]
+
+    repaired = ensure_mesh_check(steps, "icoFoam")
+
+    assert [step.command for step in repaired] == ["blockMesh", "checkMesh", "icoFoam"]
+
+
+@pytest.mark.parametrize(
+    ("steps", "expected"),
+    [
+        ([ExecutionStep("blockMesh")], ["blockMesh", "checkMesh"]),
+        (
+            [ExecutionStep("blockMesh"), ExecutionStep("checkMesh")],
+            ["blockMesh", "checkMesh"],
+        ),
+    ],
+)
+def test_mesh_only_application_has_one_final_mesh_check(
+    steps: list[ExecutionStep],
+    expected: list[str],
+) -> None:
+    """Mesh tutorials legitimately declare blockMesh as their application."""
+    repaired = ensure_mesh_check(steps, "blockMesh")
+
+    assert [step.command for step in repaired] == expected
+
+
+def test_checkmesh_application_is_not_duplicated_without_mesh_generation() -> None:
+    repaired = ensure_mesh_check([ExecutionStep("checkMesh")], "checkMesh")
+
+    assert [step.command for step in repaired] == ["checkMesh"]
+
+
+def test_comment_and_readme_dependency_keywords_do_not_block_case_import(tmp_path: Path) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    (source / "README.md").write_text(
+        "This document mentions coded function objects and #include examples.\n",
+        encoding="utf-8",
+    )
+    control_dict = source / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8")
+        + "// #include \"local-overrides\"\n/* coded codeExecute libs (\"not-real.so\") */\n",
+        encoding="utf-8",
+    )
+
+    manifest = import_case(source, tmp_path / "output")
+
+    assert manifest.supported
+    assert manifest.blocking_issues == []
+    assert manifest.detected_libraries == []
+
+
+def test_allrun_parser_accepts_standard_multiline_foundation_syntax() -> None:
+    steps = parse_allrun(
+        """#!/bin/sh
+cd ${0%/*} || exit 1
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+application=$(getApplication)
+runApplication blockMesh \\
+    -dict system/blockMeshDict
+runParallel $application -parallel
+""",
+        "icoFoam",
+    )
+
+    assert [(step.command, step.args, step.parallel) for step in steps] == [
+        ("blockMesh", ("-dict", "system/blockMeshDict"), False),
+        ("icoFoam", ("-parallel",), True),
+    ]
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "runApplication icoFoam; touch pwned",
+        "runApplication icoFoam > output",
+        "runApplication icoFoam $(id)",
+        "runApplication icoFoam -case ../other-case",
+        "runApplication icoFoam -case=/tmp/other-case",
+        "runApplication icoFoam $WM_PROJECT_DIR",
+        "runParallel blockMesh",
+        "rm -rf .",
+    ],
+)
+def test_allrun_parser_rejects_shell_escape_and_unsafe_execution(line: str) -> None:
+    with pytest.raises(CaseImportError):
+        parse_allrun(line + "\n", "icoFoam")
+
+
+def test_allrun_parser_rejects_unfinished_continuation() -> None:
+    with pytest.raises(CaseImportError, match="unfinished line continuation"):
+        parse_allrun("runApplication icoFoam " + chr(92), "icoFoam")
+
+
+def test_controlled_allrun_stops_solver_when_checkmesh_reports_failed_checks(
+    tmp_path: Path,
+) -> None:
+    """A zero exit from checkMesh is insufficient without a semantic Mesh OK gate."""
+    case_dir = tmp_path / "case"
+    controlled_dir = case_dir / ".foamagent"
+    controlled_dir.mkdir(parents=True)
+    fake_foam = tmp_path / "fake-openfoam"
+    app_bin = fake_foam / "appbin"
+    run_functions = fake_foam / "bin" / "tools" / "RunFunctions"
+    app_bin.mkdir(parents=True)
+    run_functions.parent.mkdir(parents=True)
+    run_functions.write_text(
+        """runApplication() {
+    \"$@\" > \"log.$1\" 2>&1
+}
+runParallel() {
+    runApplication \"$@\"
+}
+""",
+        encoding="utf-8",
+    )
+    (app_bin / "checkMesh").write_text(
+        "#!/bin/sh\nprintf 'Failed 1 mesh checks.\\n'\nexit 0\n",
+        encoding="utf-8",
+    )
+    (app_bin / "icoFoam").write_text(
+        "#!/bin/sh\ntouch solver-was-run\nprintf 'End\\n'\n",
+        encoding="utf-8",
+    )
+    for command in (app_bin / "checkMesh", app_bin / "icoFoam"):
+        command.chmod(command.stat().st_mode | stat.S_IXUSR)
+
+    script = controlled_dir / "Allrun.controlled"
+    script_text = render_controlled_allrun(
+        [ExecutionStep("checkMesh"), ExecutionStep("icoFoam")]
+    )
+    script.write_text(script_text, encoding="utf-8")
+    environment = {
+        **os.environ,
+        "WM_PROJECT_DIR": str(fake_foam),
+        "WM_PROJECT_VERSION": "10",
+        "FOAM_APPBIN": str(app_bin),
+        "PATH": f"{app_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+    }
+
+    result = subprocess.run(
+        ["/bin/sh", str(script)],
+        cwd=case_dir,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert "foamagent_require_mesh_ok()" in script_text
+    assert "foamagent_require_mesh_ok || exit $?" in script_text
+    assert result.returncode == 65
+    assert "refusing to start a solver" in result.stderr
+    assert "Failed 1 mesh checks." in (case_dir / "log.checkMesh").read_text(
+        encoding="utf-8"
+    )
+    assert not (case_dir / "solver-was-run").exists()
+
+
+def test_safe_repairs_are_gated_by_error_type_and_leave_numbers_unchanged(
+    tmp_path: Path,
+) -> None:
+    case = _write_foundation_case(tmp_path / "case")
+    control_dict = case / "system" / "controlDict"
+    malformed = control_dict.read_text(encoding="utf-8").replace(
+        "object controlDict;", "object wrongName;"
+    )
+    control_dict.write_text(malformed, encoding="utf-8")
+    before = numeric_snapshot(case)
+
+    repairs = apply_safe_repairs(case, [{"error_content": "segmentation fault"}])
+
+    assert repairs == []
+    assert control_dict.read_text(encoding="utf-8") == malformed
+    assert numeric_snapshot(case) == before
+
+
+def test_missing_non_numeric_semicolon_repair_preserves_whole_case_numeric_snapshot(
+    tmp_path: Path,
+) -> None:
+    case = _write_foundation_case(tmp_path / "case")
+    control_dict = case / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8").replace(
+            "application icoFoam;", "application icoFoam // keep this comment"
+        ),
+        encoding="utf-8",
+    )
+    before = numeric_snapshot(case)
+
+    repairs = apply_safe_repairs(case, [{"error_content": "Expected ';'"}])
+
+    assert any(repair["status"] == "applied" for repair in repairs)
+    assert "application icoFoam; // keep this comment" in control_dict.read_text(encoding="utf-8")
+    assert numeric_snapshot(case) == before
+
+
+def test_object_header_repair_is_rejected_when_it_would_change_a_numeric_token(
+    tmp_path: Path,
+) -> None:
+    case = _write_foundation_case(tmp_path / "case")
+    control_dict = case / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8").replace(
+            "object controlDict;", "object 42;"
+        ),
+        encoding="utf-8",
+    )
+    before = numeric_snapshot(case)
+
+    repairs = apply_safe_repairs(case, [{"error_content": "FoamFile object mismatch"}])
+
+    assert repairs == [
+        {
+            "file": "system/controlDict",
+            "status": "rejected",
+            "reason": "repair would alter numeric tokens or their line bindings",
+        }
+    ]
+    assert "object 42;" in control_dict.read_text(encoding="utf-8")
+    assert numeric_snapshot(case) == before
+
+
+def test_object_header_repair_targets_the_real_foamfile_header_not_a_comment(
+    tmp_path: Path,
+) -> None:
+    case = _write_foundation_case(tmp_path / "case")
+    control_dict = case / "system" / "controlDict"
+    control_dict.write_text(
+        "// object misleadingComment;\n"
+        + control_dict.read_text(encoding="utf-8").replace(
+            "object controlDict;", "object wrongName;"
+        ),
+        encoding="utf-8",
+    )
+
+    repairs = apply_safe_repairs(case, [{"error_content": "FoamFile object mismatch"}])
+
+    repaired = control_dict.read_text(encoding="utf-8")
+    assert any(repair["status"] == "applied" for repair in repairs)
+    assert "// object misleadingComment;" in repaired
+    assert "object controlDict;" in repaired
+    assert "object wrongName;" not in repaired
+
+
+def test_repeated_repairable_error_stops_after_one_retry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = _write_foundation_case(tmp_path / "source")
+    control_dict = source / "system" / "controlDict"
+    control_dict.write_text(
+        control_dict.read_text(encoding="utf-8").replace(
+            "object controlDict;", "object wrongName;"
+        ),
+        encoding="utf-8",
+    )
+    manifest = import_case(source, tmp_path / "output")
+    calls = 0
+
+    def same_error(*_args: object, **_kwargs: object) -> list[dict[str, str]]:
+        nonlocal calls
+        calls += 1
+        return [{"error_content": "FoamFile object mismatch"}]
+
+    monkeypatch.setattr(case_import, "execute_imported_case", same_error)
+    result = _run_imported_manifest(manifest, timeout=1, max_repairs=5)
+
+    assert result.status == "blocked"
+    assert calls == 2
+    assert result.attempts[-1]["terminal_reason"] == "repeated_error_fingerprint"
+    assert "object controlDict;" in (
+        tmp_path / "output" / "work" / "system" / "controlDict"
+    ).read_text(encoding="utf-8")
+    assert "object wrongName;" in (
+        tmp_path / "output" / "original" / "system" / "controlDict"
+    ).read_text(encoding="utf-8")

--- a/tests/test_faiss_config_cache.py
+++ b/tests/test_faiss_config_cache.py
@@ -1,0 +1,136 @@
+"""Regression tests for configuration-scoped FAISS loading and caching."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from config import Config  # noqa: E402
+import utils  # noqa: E402
+
+
+_INDEX_NAMES = (
+    "openfoam_allrun_scripts",
+    "openfoam_tutorials_structure",
+    "openfoam_tutorials_details",
+    "openfoam_command_help",
+)
+
+
+def _config(
+    database_path: Path,
+    *,
+    embedding_provider: str = "huggingface",
+    embedding_model: str = "test/model-a",
+) -> Config:
+    return Config(
+        database_path=database_path,
+        embedding_provider=embedding_provider,
+        embedding_model=embedding_model,
+    )
+
+
+def test_load_faiss_dbs_uses_the_configured_database_root(monkeypatch, tmp_path: Path) -> None:
+    """A programmatic Config must not silently read the repository database."""
+    monkeypatch.delenv("FOAMAGENT_DATABASE_PATH", raising=False)
+    monkeypatch.delenv("FOAMAGENT_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("FOAMAGENT_EMBEDDING_MODEL", raising=False)
+
+    database_root = tmp_path / "custom-database"
+    config = _config(database_root)
+    model_dir = database_root / "faiss" / "test_model-a"
+    for index_name in _INDEX_NAMES:
+        (model_dir / index_name).mkdir(parents=True)
+
+    embedding = object()
+    loaded_paths: list[tuple[Path, object, bool]] = []
+
+    class FakeFAISS:
+        @staticmethod
+        def load_local(path: str, embedding_model: object, *, allow_dangerous_deserialization: bool):
+            loaded_paths.append(
+                (Path(path), embedding_model, allow_dangerous_deserialization)
+            )
+            return {"loaded_from": path}
+
+    monkeypatch.setattr(utils, "get_embedding_model", lambda cfg: embedding)
+    monkeypatch.setattr(utils, "FAISS", FakeFAISS)
+
+    databases = utils.load_faiss_dbs(config)
+
+    assert set(databases) == set(_INDEX_NAMES)
+    assert {path for path, _, _ in loaded_paths} == {
+        model_dir / index_name for index_name in _INDEX_NAMES
+    }
+    assert all(loaded_embedding is embedding for _, loaded_embedding, _ in loaded_paths)
+    assert all(allow for _, _, allow in loaded_paths)
+
+
+def test_retrieve_faiss_cache_isolated_by_database_provider_and_model(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """One process must not reuse an incompatible vector store for another Config."""
+    monkeypatch.delenv("FOAMAGENT_DATABASE_PATH", raising=False)
+    monkeypatch.delenv("FOAMAGENT_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("FOAMAGENT_EMBEDDING_MODEL", raising=False)
+    monkeypatch.setattr(utils, "FAISS_DB_CACHE", {})
+
+    class FakeDocument:
+        def __init__(self, label: str) -> None:
+            self.page_content = label
+            self.metadata = {
+                "command": label,
+                "full_content": f"help for {label}",
+            }
+
+    class FakeVectorStore:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def similarity_search_with_score(self, _query: str, *, k: int):
+            assert k == 1
+            return [(FakeDocument(self.label), 0.25)]
+
+    loaded_keys: list[utils.FAISSCacheKey] = []
+
+    def fake_load(config: Config):
+        key = utils._faiss_cache_key(config)
+        loaded_keys.append(key)
+        return {"openfoam_command_help": FakeVectorStore("|".join(key))}
+
+    monkeypatch.setattr(utils, "load_faiss_dbs", fake_load)
+
+    base = _config(tmp_path / "database-a")
+    provider_changed = _config(
+        tmp_path / "database-a",
+        embedding_provider="ollama",
+        embedding_model="test/model-a",
+    )
+    model_changed = _config(
+        tmp_path / "database-a",
+        embedding_model="test/model-b",
+    )
+    path_changed = _config(tmp_path / "database-b")
+    configs = (base, provider_changed, model_changed, path_changed)
+    expected_keys = [utils._faiss_cache_key(config) for config in configs]
+
+    results = [
+        utils.retrieve_faiss("openfoam_command_help", "blockMesh", config=config)
+        for config in configs
+    ]
+    repeated_result = utils.retrieve_faiss(
+        "openfoam_command_help", "blockMesh", config=base
+    )
+
+    assert len(set(expected_keys)) == 4
+    assert loaded_keys == expected_keys
+    assert [result[0]["command"] for result in results] == [
+        "|".join(key) for key in expected_keys
+    ]
+    assert repeated_result[0]["command"] == "|".join(expected_keys[0])
+    assert len(utils.FAISS_DB_CACHE) == 4

--- a/tests/test_foambench_cli.py
+++ b/tests/test_foambench_cli.py
@@ -1,0 +1,119 @@
+"""Lightweight boundary tests for the benchmark CLI wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "foambench_main_under_test", ROOT / "foambench_main.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prompt_wrapper_uses_default_prompt_without_precreating_output(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cli = _load_cli_module()
+    output = tmp_path / "not-created-by-wrapper"
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["foambench_main.py", "--output", str(output)],
+    )
+    monkeypatch.setattr(cli, "run_command", lambda command: captured.append(command))
+
+    cli.main()
+
+    assert not output.exists()
+    assert captured == [
+        [
+            sys.executable,
+            "src/main.py",
+            "--output_dir",
+            str(output),
+            "--prompt_path",
+            str(ROOT / "user_requirement.txt"),
+        ]
+    ]
+
+
+def test_case_wrapper_forwards_case_arguments_without_creating_output(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cli = _load_cli_module()
+    output = tmp_path / "not-created-by-wrapper"
+    case_path = tmp_path / "input case.zip"
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "foambench_main.py",
+            "--output",
+            str(output),
+            "--case_path",
+            str(case_path),
+            "--case_subdir",
+            "nested/cavity",
+            "--visualize",
+            "--overwrite_output",
+        ],
+    )
+    monkeypatch.setattr(cli, "run_command", lambda command: captured.append(command))
+
+    cli.main()
+
+    assert not output.exists()
+    assert captured == [
+        [
+            sys.executable,
+            "src/main.py",
+            "--output_dir",
+            str(output),
+            "--case_path",
+            str(case_path),
+            "--case_subdir",
+            "nested/cavity",
+            "--visualize",
+            "--overwrite_output",
+        ]
+    ]
+
+
+def test_openfoam_path_is_forwarded_as_wm_project_dir(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cli = _load_cli_module()
+    openfoam_root = tmp_path / "openfoam10"
+    (openfoam_root / "etc").mkdir(parents=True)
+    (openfoam_root / "etc" / "bashrc").write_text("# test", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["foambench_main.py", "--openfoam_path", str(openfoam_root)],
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_command",
+        lambda command, *, env=None: captured.update(command=command, env=env),
+    )
+
+    cli.main()
+
+    assert captured["env"]["WM_PROJECT_DIR"] == str(openfoam_root)

--- a/tests/test_foambench_cli.py
+++ b/tests/test_foambench_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -93,7 +94,7 @@ def test_case_wrapper_forwards_case_arguments_without_creating_output(
     ]
 
 
-def test_openfoam_path_is_forwarded_as_wm_project_dir(
+def test_openfoam_path_sources_the_environment_for_the_child_workflow(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -111,9 +112,41 @@ def test_openfoam_path_is_forwarded_as_wm_project_dir(
     monkeypatch.setattr(
         cli,
         "run_command",
-        lambda command, *, env=None: captured.update(command=command, env=env),
+        lambda command, *, env=None, openfoam_bashrc=None: captured.update(
+            command=command,
+            env=env,
+            openfoam_bashrc=openfoam_bashrc,
+        ),
     )
 
     cli.main()
 
     assert captured["env"]["WM_PROJECT_DIR"] == str(openfoam_root)
+    assert captured["openfoam_bashrc"] == str(openfoam_root / "etc" / "bashrc")
+
+
+def test_run_command_sources_bashrc_before_executing_the_workflow(monkeypatch) -> None:
+    cli = _load_cli_module()
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        captured.update(command=command, kwargs=kwargs)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    cli.run_command(
+        ["python", "src/main.py"],
+        env={"WM_PROJECT_DIR": "/opt/openfoam10"},
+        openfoam_bashrc="/opt/openfoam10/etc/bashrc",
+    )
+
+    assert captured["command"] == [
+        "bash",
+        "-c",
+        'source "$1" && shift && exec "$@"',
+        "foamagent-benchmark",
+        "/opt/openfoam10/etc/bashrc",
+        "python",
+        "src/main.py",
+    ]
+    assert captured["kwargs"]["env"] == {"WM_PROJECT_DIR": "/opt/openfoam10"}

--- a/tests/test_imported_case_workflow.py
+++ b/tests/test_imported_case_workflow.py
@@ -1,0 +1,211 @@
+"""Workflow-level contracts for the protected ``--case_path`` graph branch."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import main as workflow_main  # noqa: E402
+from config import Config  # noqa: E402
+from nodes import imported_case_node  # noqa: E402
+
+
+def _write_case(root: Path, *, wrong_object_name: bool = False) -> Path:
+    (root / "system").mkdir(parents=True)
+    (root / "constant").mkdir()
+    object_name = "wrongName" if wrong_object_name else "controlDict"
+    (root / "system" / "controlDict").write_text(
+        """/*--------------------------------*- C++ -*----------------------------------*\\
+| OpenFOAM: The Open Source CFD Toolbox
+| Website:  https://openfoam.org
+| Version:  10
+\\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    format ascii;
+    class dictionary;
+    object %s;
+}
+application icoFoam;
+startTime 0;
+endTime 2;
+"""
+        % object_name,
+        encoding="utf-8",
+    )
+    (root / "system" / "blockMeshDict").write_text(
+        "FoamFile { object blockMeshDict; }\n", encoding="utf-8"
+    )
+    return root
+
+
+def _import_config(output: Path, *, max_loop: int = 1) -> Config:
+    config = Config()
+    config.case_dir = str(output)
+    config.max_loop = max_loop
+    config.max_time_limit = 1
+    config.recursion_limit = 20
+    return config
+
+
+def test_imported_case_uses_graph_branch_without_planner_or_llm(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = _write_case(tmp_path / "source")
+    output = tmp_path / "output"
+    calls: list[str] = []
+
+    def planner_must_not_run(_state):
+        raise AssertionError("Imported cases must not enter Planner")
+
+    def llm_must_not_be_constructed(_config):
+        raise AssertionError("Imported cases must not construct an LLM client")
+
+    def controlled_success(*_args, **_kwargs):
+        calls.append("run")
+        return []
+
+    monkeypatch.setattr(workflow_main, "planner_node", planner_must_not_run)
+    monkeypatch.setattr(workflow_main, "LLMService", llm_must_not_be_constructed)
+    monkeypatch.setattr(imported_case_node, "execute_imported_case", controlled_success)
+
+    result = workflow_main.main_imported_case(str(source), _import_config(output))
+
+    assert result["status"] == "success"
+    assert calls == ["run"]
+    assert len(result["attempts"]) == 1
+    assert result["manifest"]["application"] == "icoFoam"
+    assert (output / "original" / "system" / "controlDict").is_file()
+    assert (output / "work" / "system" / "controlDict").is_file()
+
+
+def test_imported_case_merges_into_the_common_local_runner(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = _write_case(tmp_path / "source")
+    output = tmp_path / "output"
+    common_runner_calls: list[str] = []
+    original_runner = workflow_main.local_runner_node
+
+    def controlled_success(*_args, **_kwargs):
+        return []
+
+    def common_runner(state):
+        common_runner_calls.append(state["execution_policy"])
+        return original_runner(state)
+
+    monkeypatch.setattr(imported_case_node, "execute_imported_case", controlled_success)
+    monkeypatch.setattr(workflow_main, "local_runner_node", common_runner)
+
+    result = workflow_main.main_imported_case(str(source), _import_config(output))
+
+    assert result["status"] == "success"
+    assert common_runner_calls == ["controlled_import"]
+
+
+def test_imported_case_can_explicitly_use_the_common_visualization_node(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = _write_case(tmp_path / "source")
+    output = tmp_path / "output"
+    visualization_states: list[dict] = []
+
+    def controlled_success(*_args, **_kwargs):
+        return []
+
+    def record_visualization(state):
+        visualization_states.append(state)
+        return {}
+
+    monkeypatch.setattr(imported_case_node, "execute_imported_case", controlled_success)
+    monkeypatch.setattr(workflow_main, "visualization_node", record_visualization)
+
+    result = workflow_main.main_imported_case(
+        str(source),
+        _import_config(output),
+        visualize=True,
+    )
+
+    assert result["status"] == "success"
+    assert len(visualization_states) == 1
+    assert visualization_states[0]["case_dir"] == str(output / "work")
+    assert visualization_states[0]["requires_visualization"] is True
+
+
+def test_imported_visualization_failure_is_not_reported_as_case_success(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A requested deterministic visualization is part of imported-case success."""
+    source = _write_case(tmp_path / "source")
+    output = tmp_path / "output"
+
+    def controlled_success(*_args, **_kwargs):
+        return []
+
+    def failed_visualization(_state):
+        return {
+            "pyvista_visualization": {"success": False, "error": "Xvfb unavailable"},
+            "plot_outputs": [],
+            "plot_configs": [],
+            "visualization_summary": {"pyvista_success": False},
+            "case_import_status": "visualization_failed",
+        }
+
+    monkeypatch.setattr(imported_case_node, "execute_imported_case", controlled_success)
+    monkeypatch.setattr(workflow_main, "visualization_node", failed_visualization)
+
+    result = workflow_main.main_imported_case(
+        str(source),
+        _import_config(output),
+        visualize=True,
+    )
+
+    assert result["status"] == "visualization_failed"
+
+
+def test_imported_case_graph_retries_only_an_approved_non_numeric_repair(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = _write_case(tmp_path / "source", wrong_object_name=True)
+    output = tmp_path / "output"
+    calls = 0
+    common_reviewer_calls: list[str] = []
+    original_reviewer = workflow_main.reviewer_node
+
+    def repaired_on_second_run(work_dir, *_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        control_dict = Path(work_dir) / "system" / "controlDict"
+        if calls == 1:
+            return [{"error_content": "FoamFile object mismatch"}]
+        assert "object controlDict;" in control_dict.read_text(encoding="utf-8")
+        return []
+
+    def common_reviewer(state):
+        common_reviewer_calls.append(state["repair_policy"])
+        return original_reviewer(state)
+
+    monkeypatch.setattr(imported_case_node, "execute_imported_case", repaired_on_second_run)
+    monkeypatch.setattr(workflow_main, "reviewer_node", common_reviewer)
+
+    result = workflow_main.main_imported_case(str(source), _import_config(output))
+
+    assert result["status"] == "success"
+    assert calls == 2
+    assert common_reviewer_calls == ["numeric_invariant_only"]
+    assert result["attempts"][0]["repairs"][0]["status"] == "applied"
+    assert "object wrongName;" in (output / "original" / "system" / "controlDict").read_text(
+        encoding="utf-8"
+    )
+    assert "object controlDict;" in (output / "work" / "system" / "controlDict").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_input_writer_contracts.py
+++ b/tests/test_input_writer_contracts.py
@@ -1,0 +1,395 @@
+"""Focused regression tests for InputWriter compatibility and Allrun contracts."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from utils import FoamPydantic, FoamfilePydantic  # noqa: E402
+from services import input_writer as writer_service  # noqa: E402
+
+
+class _FakeLLM:
+    def __init__(self, text_response: str = "FoamFile { version 2.0; }") -> None:
+        self.text_response = text_response
+        self.calls = []
+
+    def invoke(self, user_prompt, system_prompt, pydantic_obj=None):
+        self.calls.append(
+            {
+                "user_prompt": user_prompt,
+                "system_prompt": system_prompt,
+                "pydantic_obj": pydantic_obj,
+            }
+        )
+        if pydantic_obj is not None:
+            return pydantic_obj(commands=["blockMesh", "simpleFoam"])
+        return self.text_response
+
+
+def test_initial_node_uses_selected_solver_fork_and_requirement(monkeypatch, tmp_path):
+    writer_node = importlib.import_module("nodes.input_writer_node")
+    captured = {}
+
+    def fake_initial_write(**kwargs):
+        captured["initial"] = kwargs
+        return {
+            "dir_structure": {"system": ["blockMeshDict"]},
+            "foamfiles": FoamPydantic(list_foamfile=[]),
+        }
+
+    def fake_build_allrun(**kwargs):
+        captured["allrun"] = kwargs
+        return {"allrun_path": str(tmp_path / "Allrun"), "allrun_script": "", "commands": []}
+
+    monkeypatch.setattr(writer_node, "initial_write", fake_initial_write)
+    monkeypatch.setattr(writer_node, "build_allrun", fake_build_allrun)
+    monkeypatch.setattr(writer_node, "convert_case_to_esi_if_needed", lambda *_: None)
+    monkeypatch.setattr(writer_node, "scan_case_directory", lambda *_: {"system": ["blockMeshDict"]})
+    monkeypatch.setattr(writer_node, "read_case_foamfiles", lambda *_: FoamPydantic(list_foamfile=[]))
+
+    class Config:
+        input_writer_generation_mode = "sequential_dependency"
+        reuse_generated_dir = ""
+        openfoam_fork = "foundation"
+        database_path = str(tmp_path / "database")
+        searchdocs = 3
+
+    requirement = "Generate and validate a transient flow case."
+    state = {
+        "input_writer_mode": "initial",
+        "config": Config(),
+        "case_dir": str(tmp_path / "case"),
+        "subtasks": [],
+        "user_requirement": requirement,
+        "tutorial_reference": "",
+        "case_solver": "simpleFoam",
+        "case_stats": {"case_solver": ["icoFoam", "simpleFoam"]},
+        "similar_case_advice": None,
+        "case_info": "case solver: simpleFoam",
+        "allrun_reference": "",
+        "mesh_type": "standard_mesh",
+        "mesh_commands": [],
+    }
+
+    writer_node.input_writer_node(state)
+
+    assert captured["initial"]["case_solver"] == "simpleFoam"
+    assert captured["initial"]["openfoam_fork"] == "foundation"
+    assert captured["allrun"]["user_requirement"] == requirement
+
+
+def test_rewrite_node_passes_selected_solver_and_fork(monkeypatch, tmp_path):
+    writer_node = importlib.import_module("nodes.input_writer_node")
+    captured = {}
+
+    def fake_rewrite_files(**kwargs):
+        captured.update(kwargs)
+        return {"dir_structure": {}, "foamfiles": FoamPydantic(list_foamfile=[])}
+
+    monkeypatch.setattr(writer_node, "rewrite_files", fake_rewrite_files)
+    monkeypatch.setattr(writer_node, "convert_case_to_esi_if_needed", lambda *_: None)
+    monkeypatch.setattr(writer_node, "scan_case_directory", lambda *_: {})
+    monkeypatch.setattr(writer_node, "read_case_foamfiles", lambda *_: FoamPydantic(list_foamfile=[]))
+
+    class Config:
+        openfoam_fork = "foundation"
+
+    writer_node.input_writer_node(
+        {
+            "input_writer_mode": "rewrite",
+            "config": Config(),
+            "case_dir": str(tmp_path / "case"),
+            "case_solver": "simpleFoam",
+            "review_analysis": "Use the correct dictionary.",
+            "rewrite_plan": {"target_files": []},
+            "error_logs": [],
+            "user_requirement": "Use transient flow.",
+            "foamfiles": FoamPydantic(list_foamfile=[]),
+            "dir_structure": {},
+        }
+    )
+
+    assert captured["openfoam_fork"] == "foundation"
+    assert captured["case_solver"] == "simpleFoam"
+
+
+def test_rewrite_keeps_solver_and_foundation_contract(monkeypatch, tmp_path):
+    case_dir = tmp_path / "case"
+    (case_dir / "system").mkdir(parents=True)
+    original = FoamfilePydantic(
+        file_name="controlDict",
+        folder_name="system",
+        content="FoamFile { version 2.0; }",
+    )
+
+    class RewriteLLM(_FakeLLM):
+        def invoke(self, user_prompt, system_prompt, pydantic_obj=None):
+            self.calls.append(
+                {
+                    "user_prompt": user_prompt,
+                    "system_prompt": system_prompt,
+                    "pydantic_obj": pydantic_obj,
+                }
+            )
+            return FoamPydantic(
+                list_foamfile=[
+                    FoamfilePydantic(
+                        file_name="controlDict",
+                        folder_name="system",
+                        content="FoamFile { version 2.0; }\napplication simpleFoam;",
+                    )
+                ]
+            )
+
+    fake_llm = RewriteLLM()
+    monkeypatch.setattr(writer_service, "global_llm_service", fake_llm)
+
+    result = writer_service.rewrite_files(
+        case_dir=str(case_dir),
+        error_logs=["missing application"],
+        review_analysis="Set the solver application using Foundation conventions.",
+        rewrite_plan={"target_files": [{"file": "system/controlDict"}]},
+        user_requirement="Use steady flow.",
+        foamfiles=FoamPydantic(list_foamfile=[original]),
+        dir_structure={"system": ["controlDict"]},
+        openfoam_fork="foundation",
+        case_solver="simpleFoam",
+    )
+
+    system_prompt = fake_llm.calls[0]["system_prompt"]
+    user_prompt = fake_llm.calls[0]["user_prompt"]
+    assert "Foundation OpenFOAM v10" in system_prompt
+    assert "selected solver is simpleFoam" in system_prompt
+    assert "<openfoam_fork>foundation</openfoam_fork>" in user_prompt
+    assert "<case_solver>simpleFoam</case_solver>" in user_prompt
+    assert result["updated_files"] == ["system/controlDict"]
+    assert (case_dir / "system" / "controlDict").read_text(encoding="utf-8").endswith(
+        "application simpleFoam;"
+    )
+
+
+@pytest.mark.parametrize(
+    ("folder_name", "file_name"),
+    [
+        ("../outside", "controlDict"),
+        ("system", "../outside"),
+        ("C:/outside", "controlDict"),
+    ],
+)
+def test_rewrite_rejects_llm_paths_that_escape_case_root(
+    monkeypatch,
+    tmp_path,
+    folder_name: str,
+    file_name: str,
+):
+    case_dir = tmp_path / "case"
+    case_dir.mkdir()
+
+    class UnsafeRewriteLLM:
+        def invoke(self, *_args, **_kwargs):
+            return FoamPydantic(
+                list_foamfile=[
+                    FoamfilePydantic(
+                        file_name=file_name,
+                        folder_name=folder_name,
+                        content="attempted escape",
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(writer_service, "global_llm_service", UnsafeRewriteLLM())
+
+    with pytest.raises(ValueError, match="unsafe rewrite path"):
+        writer_service.rewrite_files(
+            case_dir=str(case_dir),
+            error_logs=["dictionary error"],
+            review_analysis="Repair only system/controlDict.",
+            rewrite_plan={"target_files": [{"file": "system/controlDict"}]},
+            user_requirement="Keep the case inside its output directory.",
+            foamfiles=FoamPydantic(list_foamfile=[]),
+            dir_structure={},
+        )
+
+    assert not (tmp_path / "outside").exists()
+    assert not (case_dir / "outside").exists()
+
+
+def test_build_allrun_command_selection_sees_requirement_and_normalizes_order(
+    monkeypatch, tmp_path
+):
+    database = tmp_path / "database"
+    raw = database / "raw"
+    raw.mkdir(parents=True)
+    (raw / "openfoam_commands.txt").write_text(
+        "blockMesh\ncheckMesh\nsimpleFoam\n", encoding="utf-8"
+    )
+
+    fake_llm = _FakeLLM(
+        """```sh
+#!/bin/sh
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+runApplication blockMesh
+runApplication simpleFoam
+runApplication checkMesh
+```"""
+    )
+    monkeypatch.setattr(writer_service, "global_llm_service", fake_llm)
+    monkeypatch.setattr(
+        writer_service,
+        "retrieve_faiss",
+        lambda *_args, **_kwargs: [{"full_content": "command help"}],
+    )
+
+    requirement = "Generate the mesh, check its quality, then run the flow solver."
+    result = writer_service.build_allrun(
+        case_dir=str(tmp_path / "case"),
+        database_path=str(database),
+        searchdocs=1,
+        dir_structure={"system": ["blockMeshDict", "controlDict"]},
+        case_info="case solver: simpleFoam",
+        allrun_reference="",
+        mesh_type="standard_mesh",
+        mesh_commands=[],
+        user_requirement=requirement,
+    )
+
+    assert requirement in fake_llm.calls[0]["user_prompt"]
+    lines = result["allrun_script"].splitlines()
+    assert lines[0] == "#!/bin/sh"
+    assert "sh" not in {line.strip() for line in lines}
+    block_index = lines.index("runApplication blockMesh")
+    check_index = lines.index("runApplication checkMesh")
+    solver_index = lines.index("runApplication simpleFoam")
+    assert block_index < check_index < solver_index
+    assert sum("checkMesh" in line for line in lines) == 1
+
+
+def test_custom_mesh_does_not_regenerate_uploaded_mesh():
+    script = """#!/bin/sh
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+runApplication blockMesh
+runApplication simpleFoam
+"""
+
+    normalized = writer_service._ensure_checkmesh_before_solver(
+        script,
+        case_info="case solver: simpleFoam",
+        dir_structure={"system": ["blockMeshDict", "controlDict"]},
+        mesh_type="custom_mesh",
+        mesh_commands=["checkMesh"],
+    )
+
+    assert "blockMesh" not in normalized
+    assert normalized.index("checkMesh") < normalized.index("simpleFoam")
+
+
+def test_mesh_utility_application_runs_checkmesh_after_its_mesh_command():
+    """Mesh tutorials use blockMesh as the application, not a flow solver."""
+    normalized = writer_service._ensure_checkmesh_before_solver(
+        "#!/bin/sh\n"
+        ". $WM_PROJECT_DIR/bin/tools/RunFunctions\n"
+        "runApplication blockMesh\n",
+        case_info="case solver: blockMesh",
+        dir_structure={"system": ["blockMeshDict", "controlDict"]},
+        mesh_type="standard_mesh",
+        mesh_commands=[],
+    )
+
+    lines = normalized.splitlines()
+    assert lines.count("runApplication blockMesh") == 1
+    assert lines.count("runApplication checkMesh") == 1
+    assert lines.index("runApplication blockMesh") < lines.index("runApplication checkMesh")
+
+
+def test_direct_allrun_commands_are_wrapped_for_retained_logs():
+    script = """#!/bin/sh
+blockMesh
+simpleFoam
+"""
+
+    normalized = writer_service._ensure_checkmesh_before_solver(
+        script,
+        case_info="case solver: simpleFoam",
+        dir_structure={"system": ["blockMeshDict", "controlDict"]},
+        mesh_type="standard_mesh",
+        mesh_commands=[],
+    )
+
+    assert ". $WM_PROJECT_DIR/bin/tools/RunFunctions" in normalized
+    assert "runApplication blockMesh" in normalized
+    assert "runApplication checkMesh" in normalized
+    assert "runApplication simpleFoam" in normalized
+
+
+def test_initial_write_passes_the_injected_llm_to_allrun(monkeypatch, tmp_path):
+    """All generation steps must share the workflow's configured LLM client."""
+    captured = {}
+
+    def fake_build_allrun(*_args, **kwargs):
+        captured.update(kwargs)
+        return {"allrun_script": "#!/bin/sh\n"}
+
+    injected_llm = _FakeLLM()
+    monkeypatch.setattr(writer_service, "build_allrun", fake_build_allrun)
+
+    writer_service.initial_write(
+        case_dir=str(tmp_path / "case"),
+        subtasks=[],
+        user_requirement="Generate a case.",
+        tutorial_reference="",
+        case_solver="icoFoam",
+        case_info="case solver: icoFoam",
+        database_path=str(tmp_path / "database"),
+        llm_service=injected_llm,
+    )
+
+    assert captured["llm_service"] is injected_llm
+
+
+def test_initial_write_rejects_duplicate_generation_targets(tmp_path):
+    with pytest.raises(ValueError, match="Duplicate generated subtask target: system/controlDict"):
+        writer_service.initial_write(
+            case_dir=str(tmp_path / "case"),
+            subtasks=[
+                {"folder_name": "system", "file_name": "controlDict"},
+                {"folder_name": "system", "file_name": "controlDict"},
+            ],
+            user_requirement="Generate a case.",
+            tutorial_reference="",
+            case_solver="icoFoam",
+            llm_service=_FakeLLM(),
+        )
+
+
+def test_initial_write_records_allrun_as_a_case_relative_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        writer_service,
+        "build_allrun",
+        lambda *_args, **_kwargs: {"allrun_script": "#!/bin/sh\n"},
+    )
+
+    result = writer_service.initial_write(
+        case_dir=str(tmp_path / "case"),
+        subtasks=[],
+        user_requirement="Generate a case.",
+        tutorial_reference="",
+        case_solver="icoFoam",
+        case_info="case solver: icoFoam",
+        database_path=str(tmp_path / "database"),
+        llm_service=_FakeLLM(),
+    )
+
+    allrun = next(
+        item
+        for item in result["foamfiles"].list_foamfile
+        if item.file_name == "Allrun"
+    )
+    assert allrun.folder_name == ""

--- a/tests/test_llm_credentials.py
+++ b/tests/test_llm_credentials.py
@@ -1,0 +1,31 @@
+"""Credential diagnostics must identify the selected LLM authentication path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from utils import LLMService  # noqa: E402
+
+
+def test_missing_codex_oauth_explains_how_to_select_api_key_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A bare API key must not look like a broken Codex login."""
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    service = object.__new__(LLMService)
+    with pytest.raises(FileNotFoundError) as exc_info:
+        service._load_codex_oauth()
+
+    message = str(exc_info.value)
+    assert "model_provider='openai-codex'" in message
+    assert "FOAMAGENT_MODEL_PROVIDER=openai" in message

--- a/tests/test_llm_structured_retries.py
+++ b/tests/test_llm_structured_retries.py
@@ -1,0 +1,114 @@
+"""Regression tests for transient structured LLM response recovery."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from pydantic import BaseModel
+import requests
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from utils import LLMService  # noqa: E402
+
+
+class _ResponseSchema(BaseModel):
+    value: int
+
+
+class _StructuredModel:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_num_tokens(self, _text: str) -> int:
+        return 1
+
+    def with_structured_output(self, _schema):
+        return self
+
+    def invoke(self, _messages):
+        self.calls += 1
+        if self.calls == 1:
+            raise ValueError("Empty response; expected JSON")
+        return _ResponseSchema(value=7)
+
+
+class _TransportThenSuccessModel:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_num_tokens(self, _text: str) -> int:
+        return 1
+
+    def invoke(self, _messages):
+        self.calls += 1
+        if self.calls == 1:
+            raise requests.exceptions.SSLError("unexpected EOF while reading")
+        return type("Response", (), {"content": "recovered"})()
+
+
+def _service_with(model: _StructuredModel) -> LLMService:
+    """Construct only the public invoke state, avoiding provider credentials."""
+    service = object.__new__(LLMService)
+    service.llm = model
+    service.model_provider = "openai"
+    service.total_calls = 0
+    service.failed_calls = 0
+    service.retry_count = 0
+    service.total_prompt_tokens = 0
+    service.total_completion_tokens = 0
+    service.total_tokens = 0
+    return service
+
+
+def test_structured_empty_response_is_retried(monkeypatch) -> None:
+    model = _StructuredModel()
+    service = _service_with(model)
+    monkeypatch.setattr("utils.time.sleep", lambda _delay: None)
+
+    result = service.invoke("request", pydantic_obj=_ResponseSchema)
+
+    assert result == _ResponseSchema(value=7)
+    assert model.calls == 2
+    assert service.retry_count == 1
+    assert service.failed_calls == 0
+
+
+def test_only_empty_or_missing_json_errors_are_retryable() -> None:
+    assert LLMService._is_retryable_structured_response_error(
+        ValueError("Empty response; expected JSON")
+    )
+    assert LLMService._is_retryable_structured_response_error(
+        ValueError("Could not find a JSON object in response: <truncated>")
+    )
+    assert not LLMService._is_retryable_structured_response_error(
+        ValueError("field required")
+    )
+
+
+def test_transient_transport_error_is_retried(monkeypatch) -> None:
+    model = _TransportThenSuccessModel()
+    service = _service_with(model)
+    monkeypatch.setattr("utils.time.sleep", lambda _delay: None)
+
+    result = service.invoke("request")
+
+    assert result == "recovered"
+    assert model.calls == 2
+    assert service.retry_count == 1
+    assert service.failed_calls == 0
+
+
+def test_only_transport_errors_are_retryable() -> None:
+    assert LLMService._is_retryable_transport_error(
+        requests.exceptions.SSLError("unexpected EOF while reading")
+    )
+    assert LLMService._is_retryable_transport_error(
+        requests.exceptions.ConnectTimeout("connection timed out")
+    )
+    assert not LLMService._is_retryable_transport_error(
+        requests.exceptions.HTTPError("401 unauthorized")
+    )

--- a/tests/test_meshing_node_contracts.py
+++ b/tests/test_meshing_node_contracts.py
@@ -1,0 +1,143 @@
+"""Regression tests for the thin meshing-node adapter."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def test_gmsh_route_preserves_case_context_and_injected_llm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The adapter must use the service signature without replacing planner output."""
+    meshing_node = importlib.import_module("nodes.meshing_node")
+    injected_llm = object()
+    captured: dict[str, object] = {}
+    expected = {"mesh_info": {"mesh_file_type": "gmsh"}, "error_logs": []}
+
+    def fake_handle_gmsh_mesh(
+        user_requirement: str,
+        case_dir: str,
+        max_loop: int,
+        *,
+        llm_service: object,
+    ) -> dict[str, object]:
+        captured.update(
+            user_requirement=user_requirement,
+            case_dir=case_dir,
+            max_loop=max_loop,
+            llm_service=llm_service,
+        )
+        return expected
+
+    monkeypatch.setattr(meshing_node, "service_handle_gmsh_mesh", fake_handle_gmsh_mesh)
+    state = {
+        "config": SimpleNamespace(max_loop=4),
+        "user_requirement": "Create a Gmsh channel mesh.",
+        "case_dir": str(tmp_path / "planned-case"),
+        "llm_service": injected_llm,
+        "mesh_type": "gmsh_mesh",
+    }
+
+    assert meshing_node.meshing_node(state) == expected
+    assert captured == {
+        "user_requirement": "Create a Gmsh channel mesh.",
+        "case_dir": str(tmp_path / "planned-case"),
+        "max_loop": 4,
+        "llm_service": injected_llm,
+    }
+
+
+def test_gmsh_service_returns_the_same_complete_contract_after_refactoring(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Mesh orchestration keeps one stable result shape for graph consumers."""
+    mesh = importlib.import_module("services.mesh")
+    case_dir = tmp_path / "case"
+    boundary_file = case_dir / "constant" / "polyMesh" / "boundary"
+
+    class FakeLLM:
+        def invoke(self, *_args: object, pydantic_obj: object = None, **_kwargs: object):
+            if pydantic_obj is None:
+                return "inlet,outlet"
+            return pydantic_obj(
+                python_code="print('generated')",
+                mesh_type="3D",
+                geometry_type="channel",
+            )
+
+    def fake_run_python(case_dir_arg: str, _python_file: str, _python_code: str) -> str:
+        Path(case_dir_arg, "geometry.msh").write_text("mesh", encoding="utf-8")
+        return ""
+
+    def fake_convert(case_dir_arg: str, _requirement: str, _llm: object) -> str:
+        target = Path(case_dir_arg) / "constant" / "polyMesh" / "boundary"
+        target.parent.mkdir(parents=True)
+        target.write_text("inlet\n{\n}\noutlet\n{\n}\n", encoding="utf-8")
+        return str(target)
+
+    monkeypatch.setattr(mesh, "_run_gmsh_python", fake_run_python)
+    monkeypatch.setattr(mesh, "_convert_gmsh_mesh", fake_convert)
+    monkeypatch.setattr(mesh, "run_checkmesh_and_correct", lambda *_args, **_kwargs: (True, False, ""))
+    monkeypatch.setattr(mesh, "_update_boundary_file", lambda *_args, **_kwargs: None)
+
+    result = mesh.handle_gmsh_mesh(
+        "Create a channel with inlet and outlet.",
+        str(case_dir),
+        max_loop=1,
+        llm_service=FakeLLM(),
+    )
+
+    assert result["custom_mesh_used"] is True
+    assert result["mesh_file_destination"] == str(case_dir / "geometry.msh")
+    assert result["mesh_info"]["mesh_description"] == "GMSH generated channel mesh"
+    assert result["error_logs"] == []
+    assert boundary_file.exists()
+
+
+def test_gmsh_boundary_validation_accepts_extra_valid_patches(
+    tmp_path: Path,
+) -> None:
+    """Requested patch names are required, but OpenFOAM may have extra patches."""
+    mesh = importlib.import_module("services.mesh")
+    boundary_file = tmp_path / "boundary"
+    boundary_file.write_text(
+        "inlet\n{\n}\noutlet\n{\n}\nwalls\n{\n}\nfrontAndBack\n{\n}\n",
+        encoding="utf-8",
+    )
+
+    mismatch, corrected = mesh._correct_boundary_mismatch(
+        str(boundary_file),
+        ["inlet", "outlet"],
+        user_requirement="Channel with inlet and outlet",
+        python_code="print('mesh')",
+        llm_client=object(),
+    )
+
+    assert mismatch is False
+    assert corrected is None
+
+
+def test_gmsh_attempt_cleanup_removes_stale_mesh_artifacts(tmp_path: Path) -> None:
+    """A retry cannot convert a mesh produced by an earlier failed attempt."""
+    mesh = importlib.import_module("services.mesh")
+    msh_file = tmp_path / "geometry.msh"
+    boundary_file = tmp_path / "constant" / "polyMesh" / "boundary"
+    msh_file.write_text("stale mesh", encoding="utf-8")
+    boundary_file.parent.mkdir(parents=True)
+    boundary_file.write_text("stale boundary", encoding="utf-8")
+
+    mesh._clear_gmsh_attempt_outputs(str(tmp_path))
+
+    assert not msh_file.exists()
+    assert not boundary_file.parent.exists()

--- a/tests/test_plan_retrieval.py
+++ b/tests/test_plan_retrieval.py
@@ -1,0 +1,317 @@
+"""Focused tests for metadata-safe tutorial retrieval."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from services import plan  # noqa: E402
+
+
+def _candidate(
+    *,
+    name: str,
+    domain: str,
+    solver: str,
+    score: float,
+    structure: str,
+    full_content: str,
+    category: str = "None",
+) -> dict[str, Any]:
+    return {
+        "case_name": name,
+        "case_domain": domain,
+        "case_category": category,
+        "case_solver": solver,
+        "score": score,
+        "dir_structure": structure,
+        "full_content": full_content,
+    }
+
+
+def _advice() -> plan.SimilarCaseAdviceModel:
+    return plan.SimilarCaseAdviceModel(
+        match_level="high",
+        use_scope="compatible files",
+        advice="Use the compatible reference.",
+    )
+
+
+def test_parse_requirement_rejects_path_traversal_case_name(monkeypatch) -> None:
+    class MaliciousPlannerLLM:
+        def invoke(self, *_args, **_kwargs):
+            return plan.CaseSummaryModel(
+                case_name="../escape",
+                case_domain="incompressible",
+                case_category="tutorial",
+                case_solver="icoFoam",
+            )
+
+    monkeypatch.setattr(plan, "global_llm_service", MaliciousPlannerLLM())
+
+    with pytest.raises(ValueError, match="Unsafe generated case name"):
+        plan.parse_requirement_to_case_info(
+            "Generate a cavity case.",
+            {
+                "case_domain": ["incompressible"],
+                "case_category": ["tutorial"],
+                "case_solver": ["icoFoam"],
+            },
+        )
+
+
+def test_truncation_preserves_tree_file_names_and_small_files() -> None:
+    reference = """<index>case name: genericCase</index>
+<directory_structure>
+<dir>directory name: constant. File names in this directory: [largeData, settings]</dir>
+</directory_structure>
+<tutorials>
+<directory_begin>directory name: constant
+<file_begin>file name: largeData
+<file_content>HEADER
+{large_content}
+TAIL</file_content>
+</file_end>
+<file_begin>file name: settings
+<file_content>importantSetting  true;</file_content>
+</file_end>
+</directory_end>
+</tutorials>""".format(large_content="x" * 2_000)
+
+    cropped = plan._truncate_large_reference_files(
+        reference,
+        per_file_limit=160,
+        total_content_limit=1_000,
+    )
+
+    assert "<directory_structure>" in cropped
+    assert "file name: largeData" in cropped
+    assert "file name: settings" in cropped
+    assert "importantSetting  true;" in cropped
+    assert "reference content omitted" in cropped
+    assert "HEADER" not in cropped
+    assert "TAIL" not in cropped
+    assert "x" * 500 not in cropped
+
+
+def test_rerank_uses_generic_case_name_terms_before_vector_score() -> None:
+    candidates = [
+        {
+            "case_name": "unrelatedExample",
+            "case_solver": "sharedSolver",
+            "score": 0.01,
+        },
+        {
+            "case_name": "thermalMixing",
+            "case_solver": "sharedSolver",
+            "score": 0.5,
+        },
+    ]
+
+    ranked = plan._rerank_candidates(
+        candidates,
+        "sharedSolver",
+        "Model transient thermal mixing in a vessel.",
+    )
+
+    assert ranked[0]["case_name"] == "thermalMixing"
+
+
+def test_retrieve_references_expands_recall_and_loads_exact_details(monkeypatch) -> None:
+    target_structure = (
+        "<dir>directory name: 0. File names in this directory: [U]</dir>\n"
+        "<dir>directory name: constant. File names in this directory: "
+        "[largeData, solverProperties]</dir>"
+    )
+    other_structure = (
+        "<dir>directory name: 0. File names in this directory: [wrongField]</dir>"
+    )
+    target_details = f"""<index>
+case name: compatibleCase
+case domain: particles
+case category: None
+case solver: particleSolver
+</index>
+<directory_structure>{target_structure}</directory_structure>
+<tutorials>
+<file_begin>file name: largeData
+<file_content>{'p' * 30_000}</file_content>
+</file_end>
+<file_begin>file name: solverProperties
+<file_content>correctSetting true;</file_content>
+</file_end>
+</tutorials>"""
+
+    structure_candidates = [
+        _candidate(
+            name="wrongDomain",
+            domain="compressible",
+            solver="particleSolver",
+            score=0.01,
+            structure=other_structure,
+            full_content="structure-only-wrong-domain",
+        ),
+        _candidate(
+            name="wrongSolver",
+            domain="particles",
+            solver="otherSolver",
+            score=0.02,
+            structure=other_structure,
+            full_content="structure-only-wrong-solver",
+        ),
+        _candidate(
+            name="compatibleCase",
+            domain="particles",
+            solver="particleSolver",
+            score=5.0,
+            structure=target_structure,
+            full_content="structure-only-target",
+        ),
+    ]
+    detail_candidates = [
+        # Same metadata but a different tree: exact tree must win over score.
+        _candidate(
+            name="compatibleCase",
+            domain="particles",
+            solver="particleSolver",
+            score=0.01,
+            structure=other_structure,
+            full_content="wrong duplicate details",
+        ),
+        _candidate(
+            name="compatibleCase",
+            domain="particles",
+            solver="particleSolver",
+            score=10.0,
+            structure=target_structure,
+            full_content=target_details,
+        ),
+        _candidate(
+            name="anotherCase",
+            domain="particles",
+            solver="particleSolver",
+            score=0.001,
+            structure=target_structure,
+            full_content="wrong case details",
+        ),
+    ]
+    calls: list[tuple[str, str, int]] = []
+    retrieval_config = object()
+    received_configs: list[object | None] = []
+
+    def fake_retrieve(database_name: str, query: str, topk: int = 1, **kwargs):
+        calls.append((database_name, query, topk))
+        received_configs.append(kwargs.get("config"))
+        if database_name == "openfoam_tutorials_structure":
+            return structure_candidates
+        if database_name == "openfoam_tutorials_details":
+            return detail_candidates
+        if database_name == "openfoam_allrun_scripts":
+            return [{"full_content": "runApplication particleSolver"}]
+        raise AssertionError(f"Unexpected database: {database_name}")
+
+    monkeypatch.setattr(plan, "retrieve_faiss", fake_retrieve)
+    monkeypatch.setattr(plan, "_build_advice", lambda *args, **kwargs: _advice())
+
+    details, structure, counts, allrun, advice = plan.retrieve_references(
+        case_name="newCase",
+        case_solver="particleSolver",
+        case_domain="particles",
+        case_category="None",
+        searchdocs=2,
+        user_requirement="Simulate a generic particle flow.",
+        config=retrieval_config,
+    )
+
+    assert [call[0] for call in calls] == [
+        "openfoam_tutorials_structure",
+        "openfoam_tutorials_details",
+        "openfoam_allrun_scripts",
+    ]
+    assert received_configs == [retrieval_config, retrieval_config, retrieval_config]
+    assert calls[0][2] >= 200
+    assert calls[1][2] >= 50
+    assert "generic particle flow" in calls[0][1]
+    assert structure == target_structure
+    assert "There are 1 files in Directory: 0" in counts
+    assert "correctSetting true;" in details
+    assert "wrong duplicate details" not in details
+    assert "structure-only-target" not in details
+    assert "reference content omitted" in details
+    assert "p" * 100 not in details
+    assert "runApplication particleSolver" in allrun
+    assert advice.match_level == "high"
+
+
+def test_retrieve_references_does_not_fall_back_to_wrong_solver(monkeypatch) -> None:
+    structure = "<dir>directory name: 0. File names in this directory: [U]</dir>"
+    calls: list[str] = []
+
+    def fake_retrieve(database_name: str, query: str, topk: int = 1):
+        calls.append(database_name)
+        return [
+            _candidate(
+                name="wrongSolverCase",
+                domain="fluid",
+                solver="otherSolver",
+                score=0.0,
+                structure=structure,
+                full_content="wrong solver contents",
+            )
+        ]
+
+    monkeypatch.setattr(plan, "retrieve_faiss", fake_retrieve)
+    monkeypatch.setattr(plan, "_build_advice", lambda *args, **kwargs: _advice())
+
+    result = plan.retrieve_references(
+        case_name="newCase",
+        case_solver="requiredSolver",
+        case_domain="fluid",
+        case_category="None",
+        user_requirement="Run a fluid case.",
+    )
+
+    assert result[:4] == ("", "", "", "")
+    assert calls == ["openfoam_tutorials_structure"]
+
+
+def test_details_require_the_same_directory_structure(monkeypatch) -> None:
+    selected_structure = (
+        "<dir>directory name: 0. File names in this directory: [U]</dir>"
+    )
+    different_structure = (
+        "<dir>directory name: 0. File names in this directory: [T]</dir>"
+    )
+    selected = _candidate(
+        name="sameMetadata",
+        domain="fluid",
+        solver="flowSolver",
+        score=1.0,
+        structure=selected_structure,
+        full_content="structure entry",
+    )
+    wrong_tree_detail = _candidate(
+        name="sameMetadata",
+        domain="fluid",
+        solver="flowSolver",
+        score=0.0,
+        structure=different_structure,
+        full_content="details for another tree",
+    )
+
+    monkeypatch.setattr(
+        plan,
+        "retrieve_faiss",
+        lambda *_args, **_kwargs: [wrong_tree_detail],
+    )
+
+    assert (
+        plan._retrieve_matching_details(selected, selected_structure, recall_k=50)
+        is None
+    )

--- a/tests/test_run_local_semantics.py
+++ b/tests/test_run_local_semantics.py
@@ -1,0 +1,378 @@
+"""Unit tests for local OpenFOAM execution and semantic validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from services import run_local  # noqa: E402
+from services.allrun_commands import command_positions  # noqa: E402
+from utils import check_foam_errors, run_command  # noqa: E402
+
+
+def _make_case(tmp_path: Path, allrun: str) -> Path:
+    case = tmp_path / "case"
+    (case / "constant").mkdir(parents=True)
+    (case / "system").mkdir()
+    (case / "0").mkdir()
+    (case / "Allrun").write_text(allrun, encoding="utf-8")
+    return case
+
+
+def test_check_foam_errors_rejects_failed_mesh_checks_with_end(tmp_path: Path) -> None:
+    (tmp_path / "log.checkMesh").write_text(
+        "Failed 2 mesh checks.\nEnd\n",
+        encoding="utf-8",
+    )
+
+    errors = check_foam_errors(str(tmp_path))
+
+    assert len(errors) == 1
+    assert "failed mesh checks" in errors[0]["error_content"]
+
+
+def test_check_foam_errors_accepts_normal_continuity_error_text_silently(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "log.icoFoam").write_text(
+        "time step continuity errors : sum local = 0, global = 0, cumulative = 0\nEnd\n",
+        encoding="utf-8",
+    )
+
+    assert check_foam_errors(str(tmp_path)) == []
+    assert capsys.readouterr().out == ""
+
+
+def test_preflight_requires_check_mesh_after_generated_mesh(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "# runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+
+    errors = run_local.validate_openfoam_case_preflight(str(case))
+
+    assert len(errors) == 1
+    assert "does not run checkMesh after mesh generation" in errors[0]["error_content"]
+
+
+def test_preflight_rejects_non_coplanar_symmetry_plane_patch(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+    (case / "system" / "blockMeshDict").write_text(
+        "vertices\n(\n"
+        "(0 0 0) (1 0 0) (1 1 0) (0 1 0)\n"
+        "(0 0 1) (1 0 1) (1 1 1) (0 1 1)\n"
+        ");\n"
+        "boundary\n(\n"
+        "thinSides\n{\n"
+        "type symmetryPlane;\n"
+        "faces\n(\n(0 3 7 4)\n(1 2 6 5)\n);\n"
+        "}\n"
+        ");\n",
+        encoding="utf-8",
+    )
+
+    errors = run_local.validate_openfoam_case_preflight(str(case))
+
+    assert len(errors) == 1
+    assert "different planes" in errors[0]["error_content"]
+
+
+def test_preflight_requires_simulation_type_in_momentum_transport(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+    (case / "constant" / "momentumTransport.air").write_text(
+        "FoamFile {}\nlaminar\n", encoding="utf-8"
+    )
+
+    errors = run_local.validate_openfoam_case_preflight(str(case))
+
+    assert len(errors) == 1
+    assert "missing the required Foundation OpenFOAM simulationType" in errors[0]["error_content"]
+
+
+def test_preflight_does_not_accept_a_commented_simulation_type(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+    (case / "constant" / "momentumTransport").write_text(
+        "// simulationType laminar;\nFoamFile {}\n",
+        encoding="utf-8",
+    )
+
+    errors = run_local.validate_openfoam_case_preflight(str(case))
+
+    assert len(errors) == 1
+    assert "missing the required Foundation OpenFOAM simulationType" in errors[0]["error_content"]
+
+
+def test_preflight_accepts_multi_plane_generic_symmetry_patch(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+    (case / "system" / "blockMeshDict").write_text(
+        "vertices\n(\n"
+        "(0 0 0) (1 0 0) (1 1 0) (0 1 0)\n"
+        "(0 0 1) (1 0 1) (1 1 1) (0 1 1)\n"
+        ");\n"
+        "boundary\n(\n"
+        "thinSides\n{\n"
+        "type symmetry;\n"
+        "faces\n(\n(0 3 7 4)\n(1 2 6 5)\n);\n"
+        "}\n"
+        ");\n",
+        encoding="utf-8",
+    )
+
+    assert run_local.validate_openfoam_case_preflight(str(case)) == []
+
+
+def test_command_detection_ignores_shell_assignment_values() -> None:
+    assert command_positions("application=icoFoam\n", "icoFoam") == []
+
+
+def test_preflight_requires_check_mesh_before_configured_solver(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication icoFoam\n"
+        "runApplication checkMesh\n",
+    )
+    (case / "system" / "controlDict").write_text(
+        "application icoFoam;\n",
+        encoding="utf-8",
+    )
+
+    errors = run_local.validate_openfoam_case_preflight(str(case))
+
+    assert len(errors) == 1
+    assert "before the configured solver icoFoam" in errors[0]["error_content"]
+
+
+def test_preflight_accepts_mesh_utility_application_after_mesh_check(
+    tmp_path: Path,
+) -> None:
+    """A mesh tutorial can legitimately declare blockMesh as its application."""
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication checkMesh\n",
+    )
+    (case / "system" / "controlDict").write_text(
+        "application blockMesh;\n",
+        encoding="utf-8",
+    )
+
+    assert run_local.validate_openfoam_case_preflight(str(case)) == []
+
+
+def test_preflight_orders_custom_mesh_check_before_solver(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication icoFoam\n"
+        "runApplication checkMesh\n",
+    )
+    (case / "system" / "controlDict").write_text(
+        "application icoFoam;\n",
+        encoding="utf-8",
+    )
+
+    errors = run_local.validate_openfoam_case_preflight(str(case))
+
+    assert len(errors) == 1
+    assert "checkMesh must run before" in errors[0]["error_content"]
+
+
+def test_postflight_validates_explicit_custom_mesh_check(tmp_path: Path) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+    (case / "system" / "controlDict").write_text(
+        "application icoFoam;\n",
+        encoding="utf-8",
+    )
+    (case / "log.checkMesh").write_text(
+        "Failed 1 mesh checks.\nEnd\n",
+        encoding="utf-8",
+    )
+    # The postflight contract now also verifies that a declared solver
+    # produced a complete log. Keep this fixture focused on the mesh-check
+    # failure being asserted below.
+    (case / "log.icoFoam").write_text("Time = 1\nEnd\n", encoding="utf-8")
+
+    errors = run_local.validate_openfoam_case_postflight(str(case))
+
+    assert len(errors) == 1
+    assert "did not report 'Mesh OK'" in errors[0]["error_content"]
+
+
+def test_postflight_accepts_direct_command_evidence_in_allrun_output(
+    tmp_path: Path,
+) -> None:
+    case = _make_case(
+        tmp_path,
+        "checkMesh\n"
+        "icoFoam\n",
+    )
+    (case / "system" / "controlDict").write_text(
+        "application icoFoam;\n",
+        encoding="utf-8",
+    )
+    (case / "Allrun.out").write_text(
+        "Checking geometry...\nMesh OK.\nTime = 1\nEnd\n",
+        encoding="utf-8",
+    )
+
+    assert run_local.validate_openfoam_case_postflight(str(case)) == []
+
+
+def test_flow_solver_does_not_require_lagrangian_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = _make_case(
+        tmp_path,
+        "runApplication blockMesh\n"
+        "runApplication checkMesh\n"
+        "runApplication icoFoam\n",
+    )
+    (case / "system" / "controlDict").write_text(
+        "application icoFoam;\n",
+        encoding="utf-8",
+    )
+
+    def successful_cavity_run(*args, **kwargs):
+        (case / "log.blockMesh").write_text("End\n", encoding="utf-8")
+        (case / "log.checkMesh").write_text("Mesh OK.\nEnd\n", encoding="utf-8")
+        (case / "log.icoFoam").write_text("Time = 1\nEnd\n", encoding="utf-8")
+        return {"returncode": 0, "timed_out": False}
+
+    monkeypatch.setattr(run_local, "run_command", successful_cavity_run)
+
+    assert run_local.run_allrun_and_collect_errors(str(case)) == []
+
+
+def test_nonzero_exit_code_fails_even_when_solver_log_ends(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = _make_case(tmp_path, "runApplication icoFoam\n")
+
+    def failed_run(*args, **kwargs):
+        (case / "log.icoFoam").write_text("End\n", encoding="utf-8")
+        return {"returncode": 7, "timed_out": False}
+
+    monkeypatch.setattr(run_local, "run_command", failed_run)
+
+    errors = run_local.run_allrun_and_collect_errors(str(case))
+
+    assert any("return code 7" in str(error) for error in errors)
+
+
+def test_cleanup_run_artifacts_removes_only_disposable_solver_outputs(
+    tmp_path: Path,
+) -> None:
+    case = tmp_path / "case"
+    case.mkdir()
+    for directory in (
+        "0",
+        "0.5",
+        "12",
+        "processor0",
+        "processor12",
+        "postProcessing",
+        "VTK",
+        "system",
+        "processorNotes",
+    ):
+        (case / directory).mkdir()
+    (case / "log.icoFoam").write_text("old log", encoding="utf-8")
+    (case / "Allrun.out").write_text("old output", encoding="utf-8")
+    (case / "Allrun.err").write_text("old error", encoding="utf-8")
+    (case / "keep.txt").write_text("input", encoding="utf-8")
+    external = tmp_path / "external-log-target"
+    external.write_text("must survive", encoding="utf-8")
+    (case / "log.external").symlink_to(external)
+
+    run_local._cleanup_run_artifacts(str(case))
+
+    for removed in (
+        "0.5",
+        "12",
+        "processor0",
+        "processor12",
+        "postProcessing",
+        "VTK",
+        "log.icoFoam",
+        "Allrun.out",
+        "Allrun.err",
+        "log.external",
+    ):
+        assert not (case / removed).exists()
+    for retained in ("0", "system", "processorNotes", "keep.txt"):
+        assert (case / retained).exists()
+    assert external.read_text(encoding="utf-8") == "must survive"
+
+
+def test_run_command_exposes_exit_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openfoam_root = tmp_path / "openfoam"
+    (openfoam_root / "etc").mkdir(parents=True)
+    (openfoam_root / "etc" / "bashrc").write_text("", encoding="utf-8")
+    monkeypatch.setenv("WM_PROJECT_DIR", str(openfoam_root))
+
+    script = tmp_path / "Allrun"
+    script.write_text("#!/bin/sh\nexit 7\n", encoding="utf-8")
+    result = run_command(
+        str(script),
+        str(tmp_path / "Allrun.out"),
+        str(tmp_path / "Allrun.err"),
+        str(tmp_path),
+        5,
+    )
+
+    assert result == {"returncode": 7, "timed_out": False}
+
+
+def test_run_command_exposes_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openfoam_root = tmp_path / "openfoam"
+    (openfoam_root / "etc").mkdir(parents=True)
+    (openfoam_root / "etc" / "bashrc").write_text("", encoding="utf-8")
+    monkeypatch.setenv("WM_PROJECT_DIR", str(openfoam_root))
+
+    script = tmp_path / "Allrun"
+    script.write_text("#!/bin/sh\nsleep 5\n", encoding="utf-8")
+    result = run_command(
+        str(script),
+        str(tmp_path / "Allrun.out"),
+        str(tmp_path / "Allrun.err"),
+        str(tmp_path),
+        0.05,
+    )
+
+    assert result["timed_out"] is True
+    assert result["returncode"] != 0

--- a/tests/test_visualization_contracts.py
+++ b/tests/test_visualization_contracts.py
@@ -1,0 +1,164 @@
+"""Offline contracts for deterministic visualization execution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from services.visualization import (  # noqa: E402
+    ensure_foam_file,
+    generate_deterministic_pyvista_script,
+    run_pyvista_script,
+    visualize_case,
+)
+from services import visualization as visualization_service  # noqa: E402
+
+
+def test_ensure_foam_file_creates_case_named_marker(tmp_path: Path) -> None:
+    case_dir = tmp_path / "cavity"
+    case_dir.mkdir()
+
+    foam_file = ensure_foam_file(str(case_dir))
+
+    assert foam_file == "cavity.foam"
+    assert (case_dir / foam_file).is_file()
+
+
+def test_visualization_runner_requires_the_declared_artifact(tmp_path: Path) -> None:
+    ok, image, errors = run_pyvista_script(
+        str(tmp_path),
+        "from pathlib import Path\nPath('result.png').write_bytes(b'png')\n",
+        expected_png="result.png",
+        timeout_s=5,
+    )
+
+    assert ok is True
+    assert image == str(tmp_path / "result.png")
+    assert errors == []
+    assert (tmp_path / "visualization.py").is_file()
+
+
+def test_visualization_runner_rejects_success_without_expected_artifact(
+    tmp_path: Path,
+) -> None:
+    ok, image, errors = run_pyvista_script(
+        str(tmp_path),
+        "print('completed without writing an image')\n",
+        expected_png="missing.png",
+        timeout_s=5,
+    )
+
+    assert ok is False
+    assert image == ""
+    assert "expected PNG was not created" in errors[0]
+
+
+def test_visualization_runner_does_not_accept_a_stale_expected_artifact(
+    tmp_path: Path,
+) -> None:
+    stale_output = tmp_path / "visualization.png"
+    stale_output.write_bytes(b"old image")
+
+    ok, image, errors = run_pyvista_script(
+        str(tmp_path),
+        "print('completed without writing an image')\n",
+        expected_png="visualization.png",
+        timeout_s=5,
+    )
+
+    assert ok is False
+    assert image == ""
+    assert "expected PNG was not created" in errors[0]
+    assert not stale_output.exists()
+
+
+def test_visualization_runner_rejects_an_artifact_path_outside_the_case(
+    tmp_path: Path,
+) -> None:
+    external_output = tmp_path.parent / "outside.png"
+
+    ok, image, errors = run_pyvista_script(
+        str(tmp_path),
+        "print('not run because the artifact path is invalid')\n",
+        expected_png="../outside.png",
+        timeout_s=5,
+    )
+
+    assert ok is False
+    assert image == ""
+    assert "must remain inside the case directory" in errors[0]
+    assert not external_output.exists()
+
+
+def test_deterministic_pyvista_template_has_a_fixed_output_contract() -> None:
+    script = generate_deterministic_pyvista_script(
+        foam_file="case.foam",
+        output_png="visualization.png",
+        field_preference="p",
+    )
+
+    assert "pv.OpenFOAMReader" in script
+    assert "out_png" in script
+    assert "'visualization.png'" in script
+    assert "'p'" in script
+    assert "pv.start_xvfb()" in script
+    assert "Headless visualization requires Xvfb" in script
+    assert "plotter.show(" not in script
+
+
+def test_visualize_case_returns_a_complete_failure_contract_without_case_dir() -> None:
+    result = visualize_case(None, "Plot the velocity.")
+
+    assert result["plot_outputs"] == []
+    assert result["pyvista_visualization"] == {"success": False, "error": "Missing case_dir"}
+    assert result["visualization_summary"]["pyvista_success"] is False
+
+
+def test_visualize_case_prefers_the_deterministic_renderer(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    output = str(tmp_path / "visualization.png")
+    monkeypatch.setattr(visualization_service, "ensure_foam_file", lambda _case_dir: "case.foam")
+    monkeypatch.setattr(
+        visualization_service,
+        "run_pyvista_script",
+        lambda *_args, **_kwargs: (True, output, []),
+    )
+
+    result = visualize_case(str(tmp_path), "Plot pressure.")
+
+    assert result["plot_outputs"] == [output]
+    assert result["visualization_summary"]["used"] == "deterministic_template"
+    assert result["plot_configs"][0]["field_name"] == "U"
+
+
+def test_visualize_case_can_disable_the_llm_fallback(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Imported cases must not execute an LLM-generated visualization script."""
+    monkeypatch.setattr(visualization_service, "ensure_foam_file", lambda _case_dir: "case.foam")
+    monkeypatch.setattr(
+        visualization_service,
+        "run_pyvista_script",
+        lambda *_args, **_kwargs: (False, "", ["deterministic renderer unavailable"]),
+    )
+
+    def llm_must_not_run(*_args, **_kwargs):
+        raise AssertionError("LLM fallback must be disabled")
+
+    monkeypatch.setattr(visualization_service, "generate_pyvista_script", llm_must_not_run)
+
+    result = visualize_case(
+        str(tmp_path),
+        "Plot pressure.",
+        allow_llm_fallback=False,
+    )
+
+    assert result["pyvista_visualization"]["success"] is False
+    assert "LLM fallback is disabled" in result["pyvista_visualization"]["error"]

--- a/tests/test_workflow_termination.py
+++ b/tests/test_workflow_termination.py
@@ -20,6 +20,7 @@ from router_func import (  # noqa: E402
     route_after_runner,
 )
 from services.output_safety import validate_output_path  # noqa: E402
+from main import workflow_exit_code  # noqa: E402
 
 
 def test_reviewer_persists_max_loop_termination_reason(monkeypatch) -> None:
@@ -104,6 +105,11 @@ def test_meshing_route_ends_after_a_mesh_failure() -> None:
         {"error_logs": [{"file": "mesh", "error_content": "gmshToFoam failed"}]}
     ) == "__end__"
     assert route_after_meshing({"error_logs": []}) == "input_writer"
+
+
+def test_mesh_generation_failure_returns_a_nonzero_cli_exit_code() -> None:
+    assert workflow_exit_code({"termination_reason": "mesh_generation_failed"}) == 2
+    assert workflow_exit_code({"termination_reason": None}) == 0
 
 
 def test_reviewer_route_ends_at_the_retry_limit_without_visualization() -> None:

--- a/tests/test_workflow_termination.py
+++ b/tests/test_workflow_termination.py
@@ -1,0 +1,136 @@
+"""Regression tests for workflow failure-state persistence."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from nodes import planner_node as planner_module  # noqa: E402
+from nodes import reviewer_node as reviewer_module  # noqa: E402
+from router_func import (  # noqa: E402
+    route_after_case_import,
+    route_after_meshing,
+    route_after_reviewer,
+    route_after_runner,
+)
+from services.output_safety import validate_output_path  # noqa: E402
+
+
+def test_reviewer_persists_max_loop_termination_reason(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reviewer_module,
+        "review_error_logs",
+        lambda **_kwargs: ("diagnosis", ["attempt"]),
+    )
+    monkeypatch.setattr(
+        reviewer_module,
+        "generate_rewrite_plan",
+        lambda **_kwargs: {"target_files": []},
+    )
+    monkeypatch.setattr(reviewer_module, "log_review", lambda *_args: None)
+
+    class Config:
+        max_loop = 1
+
+    result = reviewer_module.reviewer_node(
+        {
+            "config": Config(),
+            "error_logs": [{"file": "Allrun", "error_content": "failed"}],
+            "loop_count": 0,
+            "history_text": [],
+            "tutorial_reference": "",
+            "foamfiles": None,
+            "user_requirement": "Run a valid case.",
+            "similar_case_advice": None,
+        }
+    )
+
+    assert result["loop_count"] == 1
+    assert result["termination_reason"] == "max_review_loop_reached"
+
+
+def test_nonempty_explicit_output_is_rejected_before_planning(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "existing-output"
+    output_dir.mkdir()
+    (output_dir / "prior-result").write_text("keep", encoding="utf-8")
+
+    def planning_must_not_run(**_kwargs):
+        raise AssertionError("protected output should fail before planning")
+
+    monkeypatch.setattr(
+        planner_module,
+        "generate_simulation_plan",
+        planning_must_not_run,
+    )
+
+    class Config:
+        case_dir = str(output_dir)
+        overwrite_case_dir = False
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        planner_module.planner_node(
+            {
+                "config": Config(),
+                "user_requirement": "Run a case.",
+                "case_stats": {},
+            }
+        )
+
+    assert (output_dir / "prior-result").read_text(encoding="utf-8") == "keep"
+
+
+def test_overwrite_rejects_repository_root() -> None:
+    with pytest.raises(ValueError, match="protected broad path"):
+        validate_output_path(ROOT)
+
+
+def test_runner_route_ends_without_visualization() -> None:
+    assert route_after_runner(
+        {"error_logs": [], "requires_visualization": False}
+    ) == "__end__"
+
+
+def test_meshing_route_ends_after_a_mesh_failure() -> None:
+    assert route_after_meshing(
+        {"error_logs": [{"file": "mesh", "error_content": "gmshToFoam failed"}]}
+    ) == "__end__"
+    assert route_after_meshing({"error_logs": []}) == "input_writer"
+
+
+def test_reviewer_route_ends_at_the_retry_limit_without_visualization() -> None:
+    class Config:
+        max_loop = 1
+
+    assert route_after_reviewer(
+        {
+            "config": Config(),
+            "loop_count": 1,
+            "requires_visualization": False,
+        }
+    ) == "__end__"
+
+
+def test_imported_case_uses_common_runner_and_reviewer_routes() -> None:
+    assert route_after_case_import({"case_import_status": "ready"}) == "local_runner"
+    assert route_after_reviewer(
+        {
+            "repair_policy": "numeric_invariant_only",
+            "case_import_status": "ready",
+        }
+    ) == "local_runner"
+    assert route_after_reviewer(
+        {
+            "repair_policy": "numeric_invariant_only",
+            "case_import_status": "blocked",
+        }
+    ) == "__end__"
+    assert route_after_reviewer({"repair_policy": "unsupported"}) == "__end__"


### PR DESCRIPTION
## Summary

This PR adds an opt-in workflow for safely importing and running existing OpenFOAM cases, without requiring a natural-language prompt to generate a new case.

## Key Changes

- Support importing an existing OpenFOAM case directory or ZIP archive through `--case_path`.
- Support selecting a specific case from multi-case archives using `--case_subdir`.
- Preserve the source case in a read-only `original/` directory and perform execution and repairs only in `work/`, preventing modification of user-provided files.
- Generate import manifests, execution history, and repair diffs under `report/` for traceability.
- Parse and validate `Allrun` under a controlled policy that allows only a limited set of Foundation OpenFOAM v10 utilities and solver commands.
- Block and report unsupported or unsafe inputs, including custom compilation, dynamic code, ESI OpenFOAM cases, and unsafe shell setup.
- Reuse the existing local runner, reviewer, deterministic safe-repair flow, and optional visualization flow for imported cases.
- Fix workflow failure propagation and source the OpenFOAM environment before execution.
- Add CLI documentation and test coverage for import behavior, workflow behavior, runner behavior, and safety policies.