### PR TITLE
fix: exclude solver output directories from the case scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,7 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below, or by adding the volunteer's WeChat account: **ZDSJTUCFD**. The volunteer will invite you to the group.
-
-<p align="center">
-  <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">
-</p>
+Chinese-speaking users can join the Foam-Agent WeChat community by adding the volunteer's WeChat account: **ZDSJTUCFD**. The volunteer will invite you to the group.
 
 ## Citation
 If you use Foam-Agent in your research, please cite our paper:

--- a/README.md
+++ b/README.md
@@ -285,11 +285,7 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below.
-
-<p align="center">
-  <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">
-</p>
+Chinese-speaking users can join the Foam-Agent WeChat community. Since the WeChat group QR code expires periodically, please add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
 
 ## Citation
 If you use Foam-Agent in your research, please cite our paper:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,11 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community. Since the WeChat group QR code expires periodically, please add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
+Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below. Since the WeChat group QR code expires periodically, you can also add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
+
+<p align="center">
+  <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">
+</p>
 
 ## Citation
 If you use Foam-Agent in your research, please cite our paper:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ docker run -it \
 
 ### Join the WeChat community
 
-Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below. Since the WeChat group QR code expires periodically, you can also add the maintainer's WeChat account directly: **ZDSJTUCFD**. The maintainer will invite you to the group.
+Chinese-speaking users can join the Foam-Agent WeChat community by scanning the QR code below, or by adding the volunteer's WeChat account: **ZDSJTUCFD**. The volunteer will invite you to the group.
 
 <p align="center">
   <img src="wechat_foamagent.JPG" alt="Foam-Agent WeChat Community QR Code" width="280">

--- a/src/utils.py
+++ b/src/utils.py
@@ -850,12 +850,40 @@ def remove_numeric_folders(case_dir: str) -> None:
                 pass
 
 
+# Directories an OpenFOAM run writes into the case, which are output rather than input:
+# every written time step ("0.02", "100", ...), the per-rank copies decomposePar makes,
+# and the post-processing trees. `0` and `0.orig` are kept -- those are the initial
+# conditions, which are part of the case.
+SOLVER_OUTPUT_PREFIXES = ("processor", "postProcessing", "VTK", "dynamicCode")
+
+
+def is_solver_output_dir(name: str) -> bool:
+    """True for a directory a solver wrote, rather than one describing the case.
+
+    scan_case_directory() feeds the reviewer and rewrite prompts, and everything it
+    returns is embedded verbatim. Including written time directories made that prompt
+    reach 22.5 MB (~5.6M tokens) on a case that had already run once -- a mesh's worth
+    of field data per time step -- which no model can accept.
+    """
+    if name in ("0", "0.orig"):
+        return False
+    if name.startswith(SOLVER_OUTPUT_PREFIXES):
+        return True
+    try:
+        float(name)  # any other float-named directory is a written time step
+    except ValueError:
+        return False
+    return True
+
+
 def scan_case_directory(case_dir: str) -> Dict[str, List[str]]:
     """
     Scan an OpenFOAM case directory and return the directory structure.
     
     This function traverses the case directory one level deep and collects
     the files in each subdirectory (typically 'system', 'constant', '0', etc.).
+    Directories the solver wrote (time steps, processor*, postProcessing) are skipped:
+    they are output, not case definition, and embedding them overflows every prompt.
     
     Args:
         case_dir (str): Path to the OpenFOAM case directory
@@ -880,10 +908,16 @@ def scan_case_directory(case_dir: str) -> Dict[str, List[str]]:
     
     # Walk through the directory tree
     for root, dirs, files in os.walk(case_dir):
-        # Only process directories one level below case_dir
         current_depth = root.rstrip(os.sep).count(os.sep)
+        # Do not descend into solver output; a processor* tree holds a full copy of the
+        # mesh and every field, and reading it is pure cost.
+        if current_depth == base_depth:
+            dirs[:] = [d for d in dirs if not is_solver_output_dir(d)]
+        # Only process directories one level below case_dir
         if current_depth == base_depth + 1:
             folder_name = os.path.relpath(root, case_dir)
+            if is_solver_output_dir(folder_name):
+                continue
             # Filter out hidden files and only include regular files
             regular_files = [f for f in files if not f.startswith('.') and os.path.isfile(os.path.join(root, f))]
             if regular_files:


### PR DESCRIPTION
### The problem

`scan_case_directory()` collects every directory one level below the case root, and everything it returns is embedded verbatim in the prompts built by `review_error_logs()` and `generate_rewrite_plan()` (`<foamfiles>{str(foamfiles)}</foamfiles>`).

Once a case has run, those directories include the time steps the solver just wrote. The reviewer prompt then carries a full copy of every field at every written time step.

Measured on a `damBreakWithObstacle` case, 32k-cell mesh, five written steps:

| directory | size |
|---|---|
| `0/` — initial conditions | 0.1 MB |
| `0.02`, `0.04`, `0.06`, `0.08`, `0.1` — solver output | 4.5 MB each |
| **`<foamfiles>` payload** | **22.5 MB ≈ 5.6M tokens** |

A `squareBend` case that had written five steady-state iterations reached 51.7 MB (~14M tokens).

No model accepts a prompt that size, so the review round fails and takes the case with it. In a 126-case benchmark run this cost 13 cases, all in the two families whose solvers write large fields (`damBreakWithObstacle`, `squareBend`). Whether it triggers depends only on timing — a run whose review rounds all happen before the solver has written anything is unaffected, which is why it can go unnoticed.

`constant/polyMesh/` is not affected: it sits two levels down and the scan only descends one.

### The change

Skip directories the solver wrote:

- any float-named directory — a written time step (`0.02`, `100`, `1e-05`)
- `processor*`, `postProcessing`, `VTK`, `dynamicCode`

`0` and `0.orig` are kept: they are initial conditions and part of the case definition. Those names are also pruned from `os.walk`'s descent, since a `processor*` tree holds another copy of the mesh and every field.

### This removes no diagnostic information

Error logs reach the reviewer through `check_foam_errors()`, which reads `log*` files at the **case root** — a separate path that `scan_case_directory()` never covered, because it only ever collected subdirectories. The Courant numbers, continuity errors and bounding warnings a reviewer needs are all in those logs. The time directories only added per-cell field values, in a form no reviewer could read anyway.

### Effect

The same case now scans to 0.079 MB, with `0/`, `constant/` and `system/` intact:

```
before  22.48 MB   folders = ['0', '0.02', '0.04', '0.06', '0.08', '0.1', 'constant', 'system']
after    0.079 MB  folders = ['0', 'constant', 'system']
```

All call sites (`input_writer_node`, `services/input_writer`, `services/review`, `mcp/fastmcp_server`) use this scan to read the case *definition*, so none of them wants solver output.
